### PR TITLE
updating the pantry finder api mysql database schema and content

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -130,7 +130,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "status_id", default: 1, null: false, unsigned: true
   end
 
-  create_table "event_dates", primary_key: "event_date_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", comment: "Record of when the event is offering their services. Used to manage capacity, generate event_hours and event_slots, and other notes.", force: :cascade do |t|
+  create_table "event_dates", primary_key: "event_date_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", comment: "Record of when the event is offering their services. Used to manage capacity, generate event_hours and event_slots, and other notes.", force: :cascade do |t|
     t.integer "esp_id", default: 0, null: false, comment: "The event_service_profile this event_date is linked to. All event_dates should be linked at least through an ad hoc profile."
     t.integer "event_id", null: false, unsigned: true
     t.integer "event_date_key", null: false, unsigned: true
@@ -146,37 +146,46 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "accept_reservations", limit: 1, null: false, comment: "Whether this event_date accepts reservations or not.", unsigned: true
     t.integer "accept_interest", limit: 1, null: false, comment: "Whether this event_date accepts general interest or not.", unsigned: true
     t.integer "published_date_key", null: false, comment: "The date the entry is allowed to be shown to the public.", unsigned: true
-    t.datetime "date_added", null: false
     t.integer "published_end_date_key", default: 0, null: false, comment: "The date the entry stops being published.", unsigned: true
     t.integer "published_end_time_key", default: 0, null: false, comment: "The time the entry stops being published", unsigned: true
     t.string "public_registration_url", default: "", null: false, comment: "URL for customers to go and register themselves for a distribution"
     t.string "private_registration_url", default: "", null: false, comment: "URL for 3rd parties to go and register customers through."
     t.integer "mobile_serve_user_id", default: 0, null: false, comment: "The user_id that mobile logins go under", unsigned: true
     t.string "mobile_serve_login_hash", default: "", null: false, comment: "The login hash that a login QR code is generated from"
+    t.datetime "date_added", null: false
     t.integer "added_by", null: false, unsigned: true
     t.datetime "last_update"
     t.integer "last_update_by", null: false, unsigned: true
     t.integer "status_id", default: 1, null: false, unsigned: true
+    t.index ["esp_id", "status_id"], name: "esp_id_2"
+    t.index ["esp_id"], name: "esp_id"
+    t.index ["event_date_key"], name: "event_date_key"
+    t.index ["event_id", "event_date_key"], name: "event_id_3"
+    t.index ["event_id", "status_id"], name: "event_id_2"
+    t.index ["event_id"], name: "event_id"
+    t.index ["published_date_key"], name: "published_date_key"
+    t.index ["status_id"], name: "status_id"
   end
 
-  create_table "event_geography_profiles", primary_key: "egp_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", comment: "The geographies an agency does and does not serve along with notes", force: :cascade do |t|
+  create_table "event_geography_profiles", primary_key: "egp_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", comment: "The geographies an agency does and does not serve along with notes", force: :cascade do |t|
     t.integer "event_id", default: 0, null: false, comment: "Event ID this esg record applies to.", unsigned: true
     t.integer "geo_profile_type_id", limit: 1, default: 1, null: false, comment: "The type of geography this respresents, e.g. specific zip codes, all zip codes in CNTY, etc... ", unsigned: true
-    t.string "geo_profile_value", limit: 100, collation: "utf8_general_ci", comment: "The geography value matched with the geo_profile_type_id, e.g. All zip codes in Franklin County Ohio would be represnted by geo_profile_type_id = 2 & geo_value = 39049."
-    t.string "exception_note", comment: "Short note to feed to customers if there is an exception. E.g. (We serve 43046 but only in Fairfield County)"
-    t.text "notes", collation: "utf8_general_ci", comment: "Additional Notes to feed out to customers to help them understand specific limitations not captured through this data."
+    t.string "geo_profile_value", limit: 100, comment: "The geography value matched with the geo_profile_type_id, e.g. All zip codes in Franklin County Ohio would be represnted by geo_profile_type_id = 2 & geo_value = 39049."
+    t.string "exception_note", collation: "utf8mb4_general_ci", comment: "Short note to feed to customers if there is an exception. E.g. (We serve 43046 but only in Fairfield County)"
+    t.text "notes", comment: "Additional Notes to feed out to customers to help them understand specific limitations not captured through this data."
     t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "added_by", null: false, comment: "user_id of the person that created this record", unsigned: true
-    t.datetime "last_update", null: false
+    t.datetime "last_update", default: -> { "CURRENT_TIMESTAMP" }
     t.integer "last_update_by", null: false, comment: "user_id of the last person to update this record", unsigned: true
     t.integer "status_id", limit: 1, default: 1, null: false, comment: "status of the record, uses codes from table status_codes", unsigned: true
     t.index ["event_id", "status_id"], name: "event_id_and_status"
+    t.index ["event_id"], name: "event"
     t.index ["geo_profile_type_id", "geo_profile_value"], name: "geo_types_values"
     t.index ["geo_profile_value"], name: "geo_values"
     t.index ["status_id"], name: "status_id"
   end
 
-  create_table "event_hours", primary_key: "event_hour_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", comment: "Record of what hours, connected to the event_dates, are available to order on, with controls for capacity. Also allows for split shifts and early closures because of low reservations.", force: :cascade do |t|
+  create_table "event_hours", primary_key: "event_hour_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", comment: "Record of what hours, connected to the event_dates, are available to order on, with controls for capacity. Also allows for split shifts and early closures because of low reservations.", force: :cascade do |t|
     t.integer "event_date_id", null: false, unsigned: true
     t.integer "capacity", null: false, comment: "The total number of appointments that can be scheduled in event_slots that roll up to this event_hour record. e.g. 25"
     t.integer "reserved", null: false, comment: "The total number of appointments that have been scheduled in event_slots that roll up to this event_hour record. e.g. 20. This number should always be less than or equal to the capacity number."
@@ -188,29 +197,34 @@ ActiveRecord::Schema.define(version: 0) do
     t.datetime "last_update"
     t.integer "last_update_by", null: false, unsigned: true
     t.integer "status_id", default: 1, null: false, unsigned: true
+    t.index ["event_date_id", "status_id"], name: "event_date_id_2"
+    t.index ["event_date_id"], name: "event_date_id"
+    t.index ["status_id"], name: "status_id"
   end
 
-  create_table "event_service_geographies", primary_key: "esg_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", comment: "The geographies an agency does and does not serve along with", force: :cascade do |t|
+  create_table "event_service_geographies", primary_key: "esg_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", comment: "The geographies an agency does and does not serve along with", force: :cascade do |t|
     t.integer "egp_id", default: 0, null: false, comment: "The event geography profile record that generated this event_service_geography", unsigned: true
     t.integer "event_id", default: 0, null: false, comment: "Event ID this esg record applies to.", unsigned: true
     t.integer "geo_type_id", limit: 1, default: 1, null: false, comment: "1-zip code , others from AT file select_list_arrays", unsigned: true
-    t.string "geo_value", limit: 100, collation: "utf8_general_ci", comment: "The geography value matched with the geo_type_id, e.g. Zip Code 43123 would be represnted by geo_type_id = 1 & geo_value = 43123."
+    t.string "geo_value", limit: 100, comment: "The geography value matched with the geo_type_id, e.g. Zip Code 43123 would be represnted by geo_type_id = 1 & geo_value = 43123."
     t.integer "trigger_exception_note", limit: 1, default: 0, null: false, comment: "If this is turned on, a text field from the event_geography_profile is shown (e.g. We serve zip code 43046 but only in Fairfield County)", unsigned: true
-    t.text "notes", collation: "utf8_general_ci", comment: "Additional Notes to feed out to customers to help them understand specific limitations not captured through this data."
+    t.text "notes", comment: "Additional Notes to feed out to customers to help them understand specific limitations not captured through this data."
     t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "added_by", null: false, comment: "user_id of the person that created this record", unsigned: true
-    t.datetime "last_update", null: false
+    t.datetime "last_update"
     t.integer "last_update_by", null: false, comment: "user_id of the last person to update this record", unsigned: true
     t.integer "status_id", limit: 1, default: 1, null: false, comment: "status of the record, uses codes from table status_codes", unsigned: true
+    t.index ["egp_id", "status_id"], name: "profile_and_status"
     t.index ["egp_id"], name: "event_geography_profile"
     t.index ["event_id", "geo_type_id", "status_id"], name: "event_geotype_status"
     t.index ["event_id", "status_id"], name: "event_id_and_status"
+    t.index ["event_id"], name: "event"
     t.index ["geo_type_id", "geo_value"], name: "geo_types_values"
     t.index ["geo_value"], name: "geo_values"
     t.index ["status_id"], name: "status_id"
   end
 
-  create_table "event_service_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "event_service_profiles", primary_key: "esp_id", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "event_id", null: false, comment: "The event_id the event_service_profile belongs to"
     t.integer "service_id", comment: "The default service type provided through the event"
     t.integer "frequency_type_id", comment: "Frequency, e.g. Every, 1st, 2nd, etc..."
@@ -218,16 +232,18 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "start_timekey", comment: "start_timekey of the distribution"
     t.integer "end_timekey", comment: "end_timekey of the distribution"
     t.integer "capacity_type", limit: 1, default: 1, null: false, comment: "(future design) the default capacity type for the event_date. Default is services, but could also choose children, seniors, etc... if you have an age specifc service that is not 1-1 with a service event. "
-    t.integer "default_capacity_daily", comment: "The default daily capacity value for the event_dates generated from the schedule profile. e.g. 100"
+    t.integer "default_capacity_daily", default: 100, null: false, comment: "The default daily capacity value for the event_dates generated from the schedule profile. e.g. 100", unsigned: true
+    t.integer "default_slot_length", default: 60, null: false, comment: "The default number of minutes an event_slot will be created with", unsigned: true
     t.integer "time_shift_id", comment: "(future design) MHM had used this to shift schedules forward or backward depending on some conditions."
-    t.integer "generate_status_id", comment: "Controls if the event_service_profile will generate dates or not. Use this status for when an event_service_profile is in a draft state, then change to generate when it is ready to start making dates."
-    t.integer "publish_status_id", null: false, comment: "Controls if the Profile is Published or not. "
-    t.integer "status_publish_event_dates", limit: 1, null: false, comment: "Default setting for whether event_dates generated from this service_profile are published", unsigned: true
-    t.integer "ed_accept_walkin", limit: 1, default: 0, null: false, comment: "Default setting for event_datese whether they accept walkins or not.", unsigned: true
+    t.integer "generate_status_id", default: 0, null: false, comment: "Controls if the event_service_profile will generate dates or not. Use this status for when an event_service_profile is in a draft state, then change to generate when it is ready to start making dates.", unsigned: true
+    t.integer "publish_status_id", default: 1, null: false, comment: "Controls if the Profile is Published or not. ", unsigned: true
+    t.integer "status_publish_event_dates", limit: 1, default: 1, null: false, comment: "Default setting for whether event_dates generated from this service_profile are published", unsigned: true
+    t.integer "publish_lead_days", default: 31, null: false, comment: "The default number of days before the event_date this entry is publicly visible.", unsigned: true
+    t.integer "ed_accept_walkin", limit: 1, default: 1, null: false, comment: "Default setting for event_datese whether they accept walkins or not.", unsigned: true
     t.integer "ed_accept_resesrvations", limit: 1, default: 0, null: false, comment: "Default setting for event_dates whether they accept reservations or not.", unsigned: true
-    t.integer "ed_accept_interest", limit: 1, default: 0, null: false, comment: "Default setting for event_dates whether they accept interest in their distribution or not.", unsigned: true
-    t.string "published_desc_short", comment: "Short description (for menus etc...) that shows when a customer makes an appointment or views information on a map. Also shows when a user selects a timeslot."
-    t.string "published_desc_long", comment: "Long description (for popups etc... ) that shows when a customer makes an appointment or views information in a menu. Replicated onto each event_date and painted in the event_details box when a customer his view_details. Could also show on the appointment confirmation screen."
+    t.integer "ed_accept_interest", limit: 1, default: 1, null: false, comment: "Default setting for event_dates whether they accept interest in their distribution or not.", unsigned: true
+    t.string "published_desc_short", comment: "Short description (for menus etc...) that shows when a customer makes an appointment or views information on a map. Also shows when a user selects a timeslot. )E.g. It is okay if you arrive late for your appointment, but please do not come early - we have a very small parking lot.)"
+    t.text "published_desc_long", comment: "Long description (for popups, more details etc... ) that shows when a customer makes an appointment or views information in a menu. Painted in the event_details box when a customer his view_details. Could also show on the appointment confirmation screen. (E.g. Our pantry is the 3rd red barn on the left after the church with the gravel parking lot, please bring IDs for all in the family. No foul language. etc...)"
     t.integer "active_date_key", null: false, comment: "The first date an event_date generated from this event can be on. e.g. if the value is 03/26/2020 no schedules can be created before this date for this event_service_profile"
     t.integer "inactive_date_key", default: 99999999, null: false, comment: "The last date an event_date generated from this event_service_profile could be generated on. All generated dates from this schedule must be <= this date."
     t.integer "last_generate_date_key", null: false, comment: "The datekey of the last time TASD records were checked or generated from this schedule profile ID."
@@ -236,9 +252,15 @@ ActiveRecord::Schema.define(version: 0) do
     t.datetime "last_update"
     t.integer "last_update_by"
     t.integer "status_id", default: 1, null: false
+    t.index ["esp_id", "status_id"], name: "esp_and_status"
+    t.index ["event_id", "generate_status_id", "status_id"], name: "event_generate_status"
+    t.index ["event_id", "status_id"], name: "event_status"
+    t.index ["event_id"], name: "event"
+    t.index ["generate_status_id", "status_id"], name: "generate_and_status"
+    t.index ["generate_status_id"], name: "generate_status"
   end
 
-  create_table "event_slots", primary_key: "event_slot_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", comment: "Record of a slot of time that appointments can be scheduled into.", force: :cascade do |t|
+  create_table "event_slots", primary_key: "event_slot_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", comment: "Record of a slot of time that appointments can be scheduled into.", force: :cascade do |t|
     t.integer "event_hour_id", null: false, unsigned: true
     t.integer "capacity", null: false, comment: "The total number of appointments that can be scheduled in this event_slot e.g. 6 (100 event_date capacity / 4 hours = 25 appointments per hour. 25 appointments per hour / (60 minutes per hour / 15 minutes per slot) = 6.25 = 6 appointments per slot."
     t.integer "reserved", null: false, comment: "The total number of appointments that have been scheduled in this event_slots e.g. 5. This number should always be less than or equal to the capacity number."
@@ -250,6 +272,9 @@ ActiveRecord::Schema.define(version: 0) do
     t.datetime "last_update"
     t.integer "last_update_by", null: false, unsigned: true
     t.integer "status_id", default: 1, null: false, unsigned: true
+    t.index ["event_hour_id", "status_id"], name: "event_hour_id_2"
+    t.index ["event_hour_id"], name: "event_hour_id"
+    t.index ["status_id"], name: "status_id"
   end
 
   create_table "events", primary_key: "event_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", comment: "programs operated by locations (agencies), each has a specific default type of service (service_type_id)", force: :cascade do |t|
@@ -269,7 +294,8 @@ ActiveRecord::Schema.define(version: 0) do
     t.string "schedule_mgmt_notes", comment: "Place to keep notes about potential changees to the agency schedule"
     t.integer "last_schedule_mgmt_datekey", null: false, comment: "Last date these scheduled were managed. Use to randomly audit, etc..."
     t.integer "last_schedule_mgmt_by", default: 0, null: false, comment: "Last User that managed the schedule information", unsigned: true
-    t.string "schedule_desc", comment: "Basic description of the schedule for this event"
+    t.string "schedule_desc", default: "", null: false, comment: "Basic description of the schedule for this event"
+    t.string "service_territory_desc", default: "", null: false, comment: "Text-based lazy description of the territory served by the event"
     t.integer "status_publish_event", limit: 1, null: false, comment: "Master control for publishing - controls whether or not this event is published, default 0 for everyone. Turn them on 1 by 1."
     t.integer "status_publish_event_dates", limit: 1, null: false, comment: "Master control for whether or not event_dates connected to this event are published or not.", unsigned: true
     t.integer "event_accept_walkin", limit: 1, default: 0, null: false, comment: "Default setting for event_service_profiles if they accept walkins or not.", unsigned: true
@@ -323,13 +349,13 @@ ActiveRecord::Schema.define(version: 0) do
     t.string "zip_plus4", limit: 10, default: "", null: false
     t.string "zip3", limit: 5, default: "", null: false
     t.string "county", limit: 60
-    t.string "fips", limit: 5, default: "", null: false, collation: "utf8_unicode_ci"
-    t.decimal "latitude", precision: 10, scale: 8, null: false
-    t.decimal "longitude", precision: 11, scale: 8, null: false
-    t.decimal "tamu_latitude", precision: 10, scale: 8, null: false
-    t.decimal "tamu_longitude", precision: 11, scale: 8, null: false
-    t.decimal "pt_latitude", precision: 10, scale: 8, null: false
-    t.decimal "pt_longitude", precision: 11, scale: 8, null: false
+    t.string "fips", limit: 5, default: "", null: false
+    t.decimal "latitude", precision: 10, scale: 8, default: "0.0", null: false
+    t.decimal "longitude", precision: 11, scale: 8, default: "0.0", null: false
+    t.decimal "tamu_latitude", precision: 10, scale: 8, default: "0.0", null: false
+    t.decimal "tamu_longitude", precision: 11, scale: 8, default: "0.0", null: false
+    t.decimal "pt_latitude", precision: 10, scale: 8, default: "0.0", null: false
+    t.decimal "pt_longitude", precision: 11, scale: 8, default: "0.0", null: false
     t.string "school_dis_num", limit: 20, default: "", null: false
     t.integer "address_status_id", limit: 1, default: 0, null: false, unsigned: true
     t.integer "last_geocode_date_key", default: 0, null: false, comment: "uses yyyymmdd format that can link to dim_dates", unsigned: true
@@ -346,7 +372,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.string "zcta", limit: 50
     t.integer "congress_dist_num", limit: 1, unsigned: true
     t.string "time_zone", limit: 100, default: "", null: false
-    t.decimal "utc_offset", precision: 4, scale: 2, null: false
+    t.decimal "utc_offset", precision: 4, scale: 2, default: "0.0", null: false
     t.string "dst", limit: 5, default: "", null: false
     t.string "geofips_block", limit: 15
     t.string "geofips_bg", limit: 12
@@ -355,6 +381,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.string "geofips_state", limit: 2
     t.integer "source_id", limit: 3, default: 0, null: false, unsigned: true
     t.text "notes"
+    t.text "pub_desc_long"
     t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "added_by", default: 0, null: false, unsigned: true
     t.timestamp "last_update", default: -> { "CURRENT_TIMESTAMP" }, null: false
@@ -364,20 +391,20 @@ ActiveRecord::Schema.define(version: 0) do
     t.index ["loc_id"], name: "loc_id"
   end
 
-  create_table "foodbank_counties", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "foodbank_counties", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "fb_id", limit: 3, unsigned: true
     t.integer "fips", comment: "County Code", unsigned: true
-    t.string "fips_five_digit", limit: 5, default: "", collation: "utf8mb4_unicode_ci"
-    t.string "county_number", limit: 3, default: "", collation: "utf8mb4_unicode_ci"
+    t.string "fips_five_digit", limit: 5, default: ""
+    t.string "county_number", limit: 3, default: ""
     t.string "state_number", limit: 2, default: "", collation: "utf8mb4_bin", comment: "state number"
-    t.string "county_name", collation: "utf8mb4_unicode_ci"
-    t.string "state", collation: "utf8mb4_unicode_ci"
-    t.string "fb_name", collation: "utf8mb4_unicode_ci"
+    t.string "county_name"
+    t.string "state"
+    t.string "fb_name"
     t.integer "is_shared_county", default: 0, unsigned: true
     t.string "is_primary_fb", limit: 2, default: "", collation: "utf8mb4_bin", comment: "Identified if it is the primary foodbank for the county or not"
     t.string "fa_raw_split_share", limit: 25, default: "", null: false
     t.integer "record_num", default: 0, null: false, unsigned: true
-    t.string "notes", default: "", collation: "utf8mb4_unicode_ci"
+    t.string "notes", default: ""
     t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "added_by", default: 0, unsigned: true
     t.datetime "last_update"
@@ -385,22 +412,22 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "status_id", limit: 1, default: 1, unsigned: true
   end
 
-  create_table "foodbanks_mini", primary_key: "fb_id", id: :integer, limit: 3, unsigned: true, default: nil, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.string "fb_name", limit: 80, null: false, collation: "utf8_general_ci"
-    t.string "fb_nickname", limit: 40, null: false, collation: "utf8_general_ci"
+  create_table "foodbanks_mini", primary_key: "fb_id", id: :integer, limit: 3, unsigned: true, default: nil, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "fb_name", limit: 80, default: "", null: false
+    t.string "fb_nickname", limit: 40, default: "", null: false
     t.string "address1", limit: 80
     t.string "address2", limit: 80
     t.string "city", limit: 60
     t.string "state", limit: 10
     t.string "zip", limit: 15
-    t.string "phone_public_help", limit: 30, null: false, comment: "Public phone number customers can call to get help."
+    t.string "phone_public_help", limit: 30, default: "", null: false, comment: "Public phone number customers can call to get help."
     t.integer "fb_type_id", limit: 1, null: false, unsigned: true
-    t.string "fb_logo", null: false
-    t.string "fb_url", null: false, comment: "Foodbank general url for their website."
-    t.string "fb_agency_locator_url", null: false, comment: "Public link for how to find food and agencies with food for this foodbank."
-    t.string "fb_volunteer_url", null: false, comment: "Public link for how to volunteer with this foodbank"
-    t.string "fb_donate_url", null: false, comment: "Public link for how to donate money to this foodbank"
-    t.string "fb_food_donate_url", null: false, comment: "Public link for how to donate food to this foodbank"
+    t.string "fb_logo", default: "", null: false
+    t.string "fb_url", default: "", null: false, comment: "Foodbank general url for their website."
+    t.string "fb_agency_locator_url", default: "", null: false, comment: "Public link for how to find food and agencies with food for this foodbank."
+    t.string "fb_volunteer_url", default: "", null: false, comment: "Public link for how to volunteer with this foodbank"
+    t.string "fb_donate_url", default: "", null: false, comment: "Public link for how to donate money to this foodbank"
+    t.string "fb_food_donate_url", default: "", null: false, comment: "Public link for how to donate food to this foodbank"
     t.string "fb_fano_url"
     t.integer "display_order", limit: 1, null: false, unsigned: true
     t.integer "live_on_pt", limit: 1, default: 2, null: false, unsigned: true
@@ -413,7 +440,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "billing_cycle_type_id", limit: 1, default: 12, null: false, comment: "12 = month 4=qty 1=yearly", unsigned: true
     t.integer "agency_contract_visibility_status", limit: 1, null: false, comment: "should we display agency contracts to this fb's agencies", unsigned: true
     t.integer "fb_contract_signing_status", limit: 1, null: false, comment: "has this fb signed the MSSA 0=NO 1=Yes", unsigned: true
-    t.string "macola_cus_no", null: false, comment: "macola customer number, agency number"
+    t.string "macola_cus_no", default: "", null: false, comment: "macola customer number, agency number"
     t.integer "number_of_pantries", null: false, unsigned: true
     t.integer "number_of_other_grocery_agencies", null: false, unsigned: true
     t.integer "nar_fy15_num_emergency_pantries", null: false, unsigned: true
@@ -456,9 +483,9 @@ ActiveRecord::Schema.define(version: 0) do
     t.string "service_states", limit: 50
     t.string "service_area_desc"
     t.column "fb_type", "enum('Feeding America','Non Feeding America','Multi Agency Network','Unknown')", default: "Unknown", null: false, comment: "what kind of foodbank is this"
-    t.string "epg_2_group", null: false, comment: "The Feeding America Environmental Peer Group the Foodbank has been assigned to"
+    t.string "epg_2_group", default: "", null: false, comment: "The Feeding America Environmental Peer Group the Foodbank has been assigned to"
     t.string "website"
-    t.string "form_master_num_default", limit: 50, default: "pt_001", null: false, collation: "utf8_general_ci"
+    t.string "form_master_num_default", limit: 50, default: "pt_001", null: false
     t.integer "age_grouping_id", limit: 2, default: 6, comment: "6 = 0-17- 18-59 60+, 31 = 0-17 18-64 65+", unsigned: true
     t.integer "senior_age_start", default: 60, null: false, comment: "what age does this locations state consider for senior, 60 or 65", unsigned: true
     t.integer "default_age_groupings_id", default: 1, null: false, unsigned: true
@@ -478,11 +505,11 @@ ActiveRecord::Schema.define(version: 0) do
     t.text "next_steps", null: false, comment: "what actions need to be taken with the foodbank"
     t.integer "viability_status", limit: 1, null: false, comment: "how viable is a client data implementation at this foodbank", unsigned: true
     t.text "viability_desc", null: false
-    t.string "fa_epg", null: false, comment: "Feeding America Environmental Peer Group peach apple, turnip, rutabega, sunchoke etc..."
-    t.string "fa_region", null: false
+    t.string "fa_epg", default: "", null: false, comment: "Feeding America Environmental Peer Group peach apple, turnip, rutabega, sunchoke etc..."
+    t.string "fa_region", default: "", null: false
     t.integer "fa_member_status", limit: 1, null: false, comment: "1 member of feeding america, 0 not a member", unsigned: true
-    t.string "usda_region", null: false
-    t.string "state_association", null: false
+    t.string "usda_region", default: "", null: false
+    t.string "state_association", default: "", null: false
     t.integer "relationship_mgr", null: false, comment: "The user id of the individual that is responsible for managing the relationship with this foodbank.", unsigned: true
     t.integer "address_status_id", limit: 1, null: false, unsigned: true
     t.integer "last_geocode_date_key", null: false, unsigned: true
@@ -500,19 +527,19 @@ ActiveRecord::Schema.define(version: 0) do
     t.decimal "pt_longitude", precision: 11, scale: 8, null: false
     t.integer "census_block", null: false, unsigned: true
     t.integer "census_block_group", null: false, unsigned: true
-    t.string "census_tract", limit: 10, null: false
+    t.string "census_tract", limit: 10, default: "", null: false
     t.string "zcta", limit: 50
     t.integer "congress_dist_num", limit: 1, unsigned: true
-    t.string "time_zone", limit: 100, null: false
+    t.string "time_zone", limit: 100, default: "", null: false
     t.decimal "utc_offset", precision: 4, scale: 2, null: false
-    t.string "dst", limit: 5, null: false
+    t.string "dst", limit: 5, default: "", null: false
     t.string "geofips_block", limit: 15
     t.string "geofips_bg", limit: 12
     t.string "geofips_tract", limit: 11
     t.string "geofips_cd", limit: 2
     t.string "geofips_state", limit: 2
     t.integer "geocluster_id", null: false, unsigned: true
-    t.string "future7", limit: 20, null: false, collation: "utf8_general_ci"
+    t.string "future7", limit: 20, default: "", null: false
     t.integer "source_id", limit: 3, null: false, unsigned: true
     t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "added_by", null: false, unsigned: true
@@ -521,33 +548,34 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "status_id", limit: 1, null: false, unsigned: true
   end
 
-  create_table "geography_profile_types", primary_key: "geo_profile_type_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
-    t.string "geo_profile_type_name", limit: 25, default: "", null: false, comment: "The type of geography this respresents, e.g. specific zip codes, all zip codes in CNTY, etc... "
-    t.text "geo_profile_notes", collation: "utf8_general_ci"
+  create_table "geography_profile_types", primary_key: "geo_profile_type_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "geo_profile_type_name", limit: 25, default: "", null: false, collation: "utf8mb4_general_ci", comment: "The type of geography this respresents, e.g. specific zip codes, all zip codes in CNTY, etc... "
+    t.string "geo_profile_notes"
+    t.text "use_instructions"
     t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "added_by", null: false, comment: "user_id of the person that created this record", unsigned: true
-    t.datetime "last_update", null: false
-    t.integer "last_update_by", null: false, comment: "user_id of the last person to update this record", unsigned: true
+    t.datetime "last_update"
+    t.integer "last_update_by", comment: "user_id of the last person to update this record", unsigned: true
     t.integer "status_id", limit: 1, default: 1, null: false, comment: "status of the record, uses codes from table status_codes", unsigned: true
   end
 
-  create_table "locations", primary_key: "loc_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", comment: "agencies as defined by their supporting food bank, typically a single physical site that operates one of more events (programs)", force: :cascade do |t|
-    t.string "loc_num", limit: 20, null: false, collation: "utf8_general_ci"
+  create_table "locations", primary_key: "loc_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", comment: "agencies as defined by their supporting food bank, typically a single physical site that operates one of more events (programs)", force: :cascade do |t|
+    t.string "loc_num", limit: 20, default: "", null: false
     t.integer "org_id", default: 0, null: false, unsigned: true
     t.integer "parent_id", limit: 2, default: 0, null: false, unsigned: true
-    t.string "loc_name", limit: 150, default: "", null: false, collation: "utf8_general_ci"
-    t.string "loc_nickname", limit: 100, null: false, collation: "utf8_general_ci"
-    t.string "address1", limit: 150, default: "", null: false, collation: "utf8_general_ci"
-    t.string "address2", limit: 150, default: "", null: false, collation: "utf8_general_ci"
-    t.string "city", limit: 60, default: "", null: false, collation: "utf8_general_ci"
-    t.string "state", limit: 60, default: "", null: false, collation: "utf8_general_ci"
-    t.string "zip", limit: 5, default: "", null: false, collation: "utf8_general_ci"
-    t.string "zip_plus4", limit: 10, null: false, collation: "utf8_general_ci"
+    t.string "loc_name", limit: 150, default: "", null: false
+    t.string "loc_nickname", limit: 100, default: "", null: false
+    t.string "address1", limit: 150, default: "", null: false
+    t.string "address2", limit: 150, default: "", null: false
+    t.string "city", limit: 60, default: "", null: false
+    t.string "state", limit: 60, default: "", null: false
+    t.string "zip", limit: 5, default: "", null: false
+    t.string "zip_plus4", limit: 10, default: "", null: false
     t.string "zip3", limit: 5
-    t.string "fips", limit: 5, null: false
-    t.string "county", limit: 60, default: "", null: false, collation: "utf8_general_ci"
-    t.string "phone", limit: 60, default: "", null: false, collation: "utf8_general_ci"
-    t.string "fax", limit: 60, default: "", null: false, collation: "utf8_general_ci"
+    t.string "fips", limit: 5, default: "", null: false
+    t.string "county", limit: 60, default: "", null: false
+    t.string "phone", limit: 60, default: "", null: false
+    t.string "fax", limit: 60, default: "", null: false
     t.integer "msa", limit: 3, null: false, unsigned: true
     t.integer "cbsa", limit: 3, null: false, unsigned: true
     t.decimal "latitude", precision: 10, scale: 8, null: false
@@ -557,7 +585,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.decimal "pt_latitude", precision: 10, scale: 8, default: "99.99999999", null: false
     t.decimal "pt_longitude", precision: 11, scale: 8, default: "999.99999999", null: false
     t.text "service_types"
-    t.string "school_dis_num", limit: 20, null: false
+    t.string "school_dis_num", limit: 20, default: "", null: false
     t.integer "address_status_id", limit: 1, null: false, unsigned: true
     t.integer "last_geocode_date_key", null: false, unsigned: true
     t.string "tamu_geo_match_type", limit: 50
@@ -569,13 +597,13 @@ ActiveRecord::Schema.define(version: 0) do
     t.decimal "smarty_tamu_difference", precision: 6, scale: 2
     t.integer "census_block", null: false, unsigned: true
     t.integer "census_block_group", null: false, unsigned: true
-    t.string "census_tract", limit: 10, null: false
+    t.string "census_tract", limit: 10, default: "", null: false
     t.string "zcta", limit: 50
     t.integer "congress_dist_num", limit: 1, unsigned: true
-    t.string "time_zone", limit: 100, null: false
+    t.string "time_zone", limit: 100, default: "", null: false
     t.string "time_zone_php", limit: 100, default: "America/New_York", null: false
     t.decimal "utc_offset", precision: 4, scale: 2, null: false
-    t.string "dst", limit: 5, null: false
+    t.string "dst", limit: 5, default: "", null: false
     t.string "geofips_block", limit: 15
     t.string "geofips_bg", limit: 12
     t.string "geofips_tract", limit: 11
@@ -583,39 +611,39 @@ ActiveRecord::Schema.define(version: 0) do
     t.string "geofips_state", limit: 2
     t.integer "primary_user_id", default: 0, null: false, unsigned: true
     t.integer "primary_fb_id", limit: 2, null: false, unsigned: true
-    t.string "alt_fb_ids", limit: 50, null: false, collation: "utf8_general_ci"
+    t.string "alt_fb_ids", limit: 50, default: "", null: false
     t.integer "loc_type_id", limit: 2, default: 0, null: false, unsigned: true
-    t.column "e_signature", "enum('Yes','No')", default: "No", null: false, collation: "utf8_general_ci"
+    t.column "e_signature", "enum('Yes','No')", default: "No", null: false
     t.integer "user_maintenance_id", limit: 1, default: 0, null: false, comment: "can this agency view users, edit users, add users - default of 0 is ", unsigned: true
-    t.column "agency_data", "enum('Yes','No')", default: "No", null: false, collation: "utf8_general_ci"
+    t.column "agency_data", "enum('Yes','No')", default: "No", null: false
     t.column "pt_id_card1", "enum('No','Yes')", default: "No", null: false, comment: "used to turn the id card feature on or off for a location. The default value should be yes after april 2016"
     t.column "pt_id_card2", "enum('No','Yes')", default: "No", null: false, comment: "used to turn the id card(mini) feature on or off for a location. The default value should be yes after april 2016"
-    t.column "pounds_served", "enum('Yes','No')", default: "No", null: false, collation: "utf8_general_ci"
-    t.column "pieces_served", "enum('Yes','No')", default: "No", null: false, collation: "utf8_general_ci"
+    t.column "pounds_served", "enum('Yes','No')", default: "No", null: false
+    t.column "pieces_served", "enum('Yes','No')", default: "No", null: false
     t.integer "primary_event_id", default: 0, null: false, unsigned: true
-    t.string "zip3_zones1", default: "", null: false, collation: "utf8_general_ci"
-    t.string "zip3_zones2", null: false, collation: "utf8_general_ci"
+    t.string "zip3_zones1", default: "", null: false
+    t.string "zip3_zones2", default: "", null: false
     t.string "search_states", limit: 40
     t.integer "scheduling_interval", limit: 2, default: 60, null: false, unsigned: true
-    t.column "agency_data_all", "enum('Yes','No')", default: "No", null: false, collation: "utf8_general_ci"
-    t.column "service_limits", "enum('Yes','No')", default: "No", null: false, collation: "utf8_general_ci"
+    t.column "agency_data_all", "enum('Yes','No')", default: "No", null: false
+    t.column "service_limits", "enum('Yes','No')", default: "No", null: false
     t.integer "age_grouping_id", limit: 2, default: 6, comment: "6 = 0-17- 18-59 60+, 31 = 0-17 18-64 65+", unsigned: true
     t.integer "senior_age_start", default: 60, null: false, comment: "what age does this locations state consider for senior, 60 or 65", unsigned: true
     t.integer "default_age_groupings_id", default: 1, null: false, unsigned: true
     t.integer "future3", null: false, unsigned: true
     t.integer "future4", null: false, unsigned: true
-    t.string "future5", limit: 30, null: false, collation: "utf8_general_ci"
-    t.string "future6", limit: 30, null: false, collation: "utf8_general_ci"
+    t.string "future5", limit: 30, default: "", null: false
+    t.string "future6", limit: 30, default: "", null: false
     t.integer "fb_rank", null: false, unsigned: true
     t.integer "fb_rank_county", null: false, unsigned: true
-    t.string "fb_tier", limit: 50, null: false
-    t.string "fb_tier_county", limit: 50, null: false
+    t.string "fb_tier", limit: 50, default: "", null: false
+    t.string "fb_tier_county", limit: 50, default: "", null: false
     t.integer "billing_status_id", limit: 1, null: false, comment: "used to tract if the location is included in the billing agencies process. this is a mechanism to permanently remove someone from the pool of paying agencies. the billing_agencies data element is then used month to month.", unsigned: true
     t.integer "billing_multiplier", limit: 1, default: 1, null: false, comment: "a mechamism to gross up or down the amount an agency is billed for. i.e. 4 sites that are one location the loc gets a billing multiplier of 4.", unsigned: true
     t.text "billing_note_external", null: false, comment: "rolling note field used to communicate with the foodbank why the agency has a certain billing multiplier"
     t.integer "contract_user_id", null: false, comment: "this is the user that is primarily responsible for signing the contract for the site. or responsible for managing the process to get the contract signed.", unsigned: true
     t.integer "privacy_bypass_status_id", limit: 1, null: false, comment: "used to exempt some agencys users from seeing the Privacy Policy, 20171023 MHM added for Salvation Army Columbus where their users are not permitted by their rules to acknowledge or sign anything", unsigned: true
-    t.string "logo", limit: 70, null: false, collation: "utf8_general_ci"
+    t.string "logo", limit: 70, default: "", null: false
     t.integer "d_date_key", null: false, comment: "the last time the warehouse RE data was calculated", unsigned: true
     t.integer "d_last_year", null: false, comment: "the number of services in the last year relative to the date key", unsigned: true
     t.integer "d_last_90_days", null: false, comment: "the number of services in the last 90 days relative to the date key", unsigned: true
@@ -630,8 +658,8 @@ ActiveRecord::Schema.define(version: 0) do
     t.text "sc_monthly_30", null: false, comment: "the monthly trend for this month, and the preceeding 12 for the service category"
     t.text "sc_monthly_35", null: false, comment: "the monthly trend for this month, and the preceeding 12 for the service category"
     t.text "sc_monthly_40", null: false, comment: "the monthly trend for this month, and the preceeding 12 for the service category "
-    t.datetime "date_added", null: false
-    t.string "added_by", limit: 150, default: "", null: false, collation: "utf8_general_ci"
+    t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "added_by", limit: 150, default: "", null: false
     t.timestamp "last_update", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "last_update_by", null: false, unsigned: true
     t.integer "status_id", limit: 1, default: 0, null: false, unsigned: true
@@ -642,34 +670,35 @@ ActiveRecord::Schema.define(version: 0) do
     t.index ["state"], name: "state"
   end
 
-  create_table "service_categories", primary_key: "service_category", id: :integer, unsigned: true, default: nil, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", comment: "categories of services that summary the service types.", force: :cascade do |t|
-    t.string "service_category_name", limit: 50, default: "", null: false, collation: "utf8_general_ci"
-    t.string "service_category_desc", null: false
+  create_table "service_categories", primary_key: "service_category", id: :integer, unsigned: true, default: nil, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", comment: "categories of services that summary the service types.", force: :cascade do |t|
+    t.string "service_category_name", limit: 50, default: "", null: false
+    t.string "service_category_desc", default: "", null: false
     t.string "color", limit: 20, default: "#FF0080", null: false
-    t.string "sc_mapping", null: false, comment: "Field used to tell where each service category data should be warehoused. Used in the events table and others."
-    t.string "notes", default: "", null: false, collation: "utf8_general_ci"
-    t.datetime "date_added", null: false
-    t.string "added_by", limit: 50, default: "", null: false, collation: "utf8_general_ci"
-    t.timestamp "last_update", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "sc_mapping", default: "", null: false, comment: "Field used to tell where each service category data should be warehoused. Used in the events table and others."
+    t.string "notes", default: "", null: false
+    t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "added_by", limit: 50, default: "", null: false
+    t.timestamp "last_update", default: -> { "CURRENT_TIMESTAMP" }
     t.integer "status_id", limit: 1, default: 2, null: false, unsigned: true
   end
 
-  create_table "service_types", primary_key: "service_id", id: :integer, limit: 2, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", comment: "types of service and categories of service that a family might receive", force: :cascade do |t|
-    t.string "service_desc", limit: 50, default: "", null: false, collation: "utf8_general_ci"
-    t.string "service_desc_long", null: false
+  create_table "service_types", primary_key: "service_id", id: :integer, limit: 2, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", comment: "types of service and categories of service that a family might receive", force: :cascade do |t|
+    t.string "service_desc", limit: 50, default: "", null: false
+    t.string "service_desc_long", default: "", null: false
     t.integer "meals_served", limit: 1, null: false, unsigned: true
     t.integer "form_type_id", limit: 1, default: 1, null: false, unsigned: true
     t.integer "grouping", limit: 2, default: 0, null: false, unsigned: true
-    t.string "group_name", limit: 50, default: "", null: false, collation: "utf8_general_ci"
+    t.string "group_name", limit: 50, default: "", null: false
     t.integer "sub_grouping", limit: 2, default: 0, null: false, unsigned: true
     t.integer "service_category1", limit: 1, null: false, unsigned: true
     t.integer "service_sub_category1", limit: 1, null: false, unsigned: true
-    t.integer "regulated_service", limit: 1, null: false, comment: "does this service typically require a USDA or State signature, this will be used to help audit signature requirements by location and event"
+    t.integer "regulated_service", limit: 1, default: 0, null: false, comment: "does this service typically require a USDA or State signature, this will be used to help audit signature requirements by location and event"
+    t.integer "grocery_service_flag", limit: 1, default: 0, unsigned: true
     t.integer "organization_id", limit: 3, default: 0, null: false, unsigned: true
-    t.string "logo", limit: 60, null: false, collation: "utf8_general_ci"
-    t.string "notes", default: "", null: false, collation: "utf8_general_ci"
-    t.datetime "date_added", null: false
-    t.string "added_by", limit: 50, default: "", null: false, collation: "utf8_general_ci"
+    t.string "logo", limit: 60, default: "", null: false
+    t.string "notes", default: "", null: false
+    t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "added_by", limit: 50, default: "", null: false
     t.timestamp "last_update", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "status_id", limit: 1, default: 2, null: false, unsigned: true
     t.index ["grouping", "sub_grouping"], name: "group_sg"
@@ -678,9 +707,9 @@ ActiveRecord::Schema.define(version: 0) do
     t.index ["sub_grouping"], name: "sg"
   end
 
-  create_table "types_service_geography", primary_key: "geo_type_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
-    t.string "geo_type_name", limit: 25, default: "", null: false, comment: "The type of geography this respresents, e.g. zip codes, CNTY, etc... "
-    t.text "geo_type_notes", collation: "utf8_general_ci"
+  create_table "types_service_geography", primary_key: "geo_type_id", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "geo_type_name", limit: 25, default: "", null: false, collation: "utf8mb4_general_ci", comment: "The type of geography this respresents, e.g. zip codes, CNTY, etc... "
+    t.text "geo_type_notes"
     t.datetime "date_added", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "added_by", null: false, comment: "user_id of the person that created this record", unsigned: true
     t.datetime "last_update"

--- a/spec/serializers/foodbank_serializer_spec.rb
+++ b/spec/serializers/foodbank_serializer_spec.rb
@@ -11,10 +11,10 @@ describe FoodbankSerializer do
 
     exp_rslt = '{"id":null,"address":"addr 1","city":"the town",' \
                  '"state":"OH","zip":"12345","phone":"999-999-9999",' \
-                 '"name":"local foodbank","nickname":null,' \
-                 '"logo":null,"display_url":"' \
+                 '"name":"local foodbank","nickname":"",' \
+                 '"logo":"","display_url":"' \
                  "#{Config.default_fb_display_url}" \
-                 '","fb_agency_locator_url":null,"fb_url":null,' \
+                 '","fb_agency_locator_url":"","fb_url":"",' \
                  '"fb_fano_url":null}'
     expect(serializer.to_json).to eql(exp_rslt)
   end
@@ -29,11 +29,11 @@ describe FoodbankSerializer do
 
     exp_rslt = '{"id":null,"address":"addr 1 addr 2","city":"the town",' \
                  '"state":"OH","zip":"12345","phone":"999-999-9999",' \
-                 '"name":"local foodbank","nickname":null,' \
-                 '"logo":null,"display_url":"' \
+                 '"name":"local foodbank","nickname":"",' \
+                 '"logo":"","display_url":"' \
                  "#{Config.default_fb_display_url}" \
-                 '","fb_agency_locator_url":null,' \
-                 '"fb_url":null,"fb_fano_url":null}'
+                 '","fb_agency_locator_url":"",' \
+                 '"fb_url":"","fb_fano_url":null}'
     expect(serializer.to_json).to eql(exp_rslt)
   end
 
@@ -49,10 +49,10 @@ describe FoodbankSerializer do
 
     exp_rslt = '{"id":null,"address":"addr 1 addr 2","city":"the town",' \
                  '"state":"OH","zip":"12345","phone":"999-999-9999",' \
-                 '"name":"local foodbank","nickname":null,' \
-                 '"logo":null,"display_url":"fb_agency_locator_url",' \
+                 '"name":"local foodbank","nickname":"",' \
+                 '"logo":"","display_url":"fb_agency_locator_url",' \
                  '"fb_agency_locator_url":"fb_agency_locator_url",'\
-                 '"fb_url":null,"fb_fano_url":null}'
+                 '"fb_url":"","fb_fano_url":null}'
     expect(serializer.to_json).to eql(exp_rslt)
   end
 
@@ -67,8 +67,8 @@ describe FoodbankSerializer do
 
     exp_rslt = '{"id":null,"address":"addr 1 addr 2","city":"the town",' \
                  '"state":"OH","zip":"12345","phone":"999-999-9999",' \
-                 '"name":"local foodbank","nickname":null,"logo":null,' \
-                 '"display_url":"fb_url","fb_agency_locator_url":null,' \
+                 '"name":"local foodbank","nickname":"","logo":"",' \
+                 '"display_url":"fb_url","fb_agency_locator_url":"",' \
                  '"fb_url":"fb_url","fb_fano_url":null}'
     expect(serializer.to_json).to eql(exp_rslt)
   end
@@ -84,9 +84,9 @@ describe FoodbankSerializer do
 
     exp_rslt = '{"id":null,"address":"addr 1 addr 2","city":"the town",' \
                  '"state":"OH","zip":"12345","phone":"999-999-9999",' \
-                 '"name":"local foodbank","nickname":null,"logo":null,' \
+                 '"name":"local foodbank","nickname":"","logo":"",' \
                  '"display_url":"fb_fano_url",' \
-                 '"fb_agency_locator_url":null,"fb_url":null,' \
+                 '"fb_agency_locator_url":"","fb_url":"",' \
                  '"fb_fano_url":"fb_fano_url"}'
     expect(serializer.to_json).to eql(exp_rslt)
   end


### PR DESCRIPTION
Updating the schema was required to add the pub_desc_long field to the event.rb factory in order to test issue #15. The schema.rb file can be viewed <[here](https://github.com/PhilNorman2/freshtrak-pantry-finder-api/blob/db-schema/db/schema.rb)>

The schema update also caused the foodbank_serializer_spec.rb  test to fail (corrected with this PR).  The following defaults changed for these foodbank_mini fields.

fb_agency_locator null->""
fb_url null->""
logo null->""
nickname null->""

note: the default for fb_fano_url remains 'null'.