### PR TITLE
added event api controller with simple method + agency_name

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  # Controller to expose Events
+  class EventsController < ApplicationController
+    before_action :set_event, only: [:show]
+
+    # GET /api/events/1
+    def show
+      render json:
+        ActiveModelSerializers::SerializableResource.new(@event)
+    end
+
+    private
+
+    def set_event
+      @event = Event.find(params[:id])
+    end
+  end
+end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -9,8 +9,13 @@ class EventSerializer < ActiveModel::Serializer
   attribute :event_name, key: :name
   attribute :service_description, key: :service
   attributes :estimated_distance, :exception_note, :event_details
+  attribute :agency_name
 
   has_many :event_dates
+
+  def agency_name
+    object.agency.loc_name
+  end
 
   def address
     return object.address1 if object.address2.nil?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Jets.application.routes.draw do
   namespace :api do
     resources :agencies, only: :index
     resources :event_dates, only: :show
+    resources :events, only: :show
     resources :foodbanks, only: :index
   end
 

--- a/spec/controllers/api/agencies_controller_spec.rb
+++ b/spec/controllers/api/agencies_controller_spec.rb
@@ -123,6 +123,7 @@ describe Api::AgenciesController, type: :controller do
               ),
               exception_note: has_zip ? event_geography.exception_note : '',
               event_details: event.pub_desc_long,
+              agency_name: agency.loc_name,
               event_dates: [
                 {
                   id: event_date.id,

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+describe Api::EventsController, type: :controller do
+  let(:event) { create(:event) }
+
+  it 'shows the event' do
+    get "/api/events/#{event.id}"
+
+    expect(response.status).to eq 200
+    event_response = JSON.parse(response.body)['event']
+    expect(event_response['id']).to eq(event.id)
+  end
+end


### PR DESCRIPTION
event endpoint with simple controller method (will only accept event_id in the path).  Added agency_name JSON data element to help with registration confirmation.

example request:

http://localhost:8888/api/events/5598

example response:

<pre>
{
    "event": {
        "id": 5598,
        "address": "112 LINCOLN AVE   ",
        "city": "PLEASANTVILLE",
        "state": "OH",
        "zip": "43148",
        "agency_id": 332,
        "latitude": "39.8083177",
        "longitude": "-82.5214868",
        "name": "Drive Thru",
        "service": "Prepack Pantry",
        "estimated_distance": "",
        "exception_note": "",
        "event_details": "",
        "agency_name": "Outreach Mission Pantry",
        "event_dates": [
            {
                "id": 2526,
                "event_id": 5598,
                "capacity": 100,
                "accept_walkin": 1,
                "accept_reservations": 0,
                "accept_interest": 1,
                "start_time": "9 AM",
                "end_time": "11 AM",
                "date": "2020-06-20"
            }
        ]
    }
}
</pre>