### PR TITLE
Event Date scope for published end datetime

### DIFF
--- a/app/models/event_date.rb
+++ b/app/models/event_date.rb
@@ -9,8 +9,11 @@ class EventDate < ApplicationRecord
   has_many :event_hours, foreign_key: :event_date_id, inverse_of: :event_date,
                          dependent: :restrict_with_exception
 
-  default_scope { active.published.event_publishes_dates.future.end_datetime }
-  scope :active, -> { where(status_id: 1) }
+  default_scope { active.published.event_publishes_dates.future }
+  scope :active, lambda {
+    where('event_dates.status_id = 1 AND ? <= published_end_datetime',
+          DateTime.current.utc.strftime('%Y-%m-%d %H:%M:%S'))
+  }
   scope :event_publishes_dates, lambda {
     joins(:event).merge(Event.publishes_dates)
   }
@@ -20,10 +23,5 @@ class EventDate < ApplicationRecord
   }
   scope :future, lambda {
     where('event_date_key >= ?', Date.today.to_s.delete('-'))
-  }
-
-  scope :end_datetime, lambda {
-    where('? <= published_end_datetime',
-          DateTime.current.utc.strftime('%Y-%m-%d %H:%M:%S'))
   }
 end

--- a/app/models/event_date.rb
+++ b/app/models/event_date.rb
@@ -9,7 +9,7 @@ class EventDate < ApplicationRecord
   has_many :event_hours, foreign_key: :event_date_id, inverse_of: :event_date,
                          dependent: :restrict_with_exception
 
-  default_scope { active.published.event_publishes_dates.future }
+  default_scope { active.published.event_publishes_dates.future.end_datetime }
   scope :active, -> { where(status_id: 1) }
   scope :event_publishes_dates, lambda {
     joins(:event).merge(Event.publishes_dates)
@@ -20,5 +20,10 @@ class EventDate < ApplicationRecord
   }
   scope :future, lambda {
     where('event_date_key >= ?', Date.today.to_s.delete('-'))
+  }
+
+  scope :end_datetime, lambda {
+    where('? <= published_end_datetime',
+          DateTime.current.utc.strftime('%Y-%m-%d %H:%M:%S'))
   }
 end

--- a/spec/factories/event_date.rb
+++ b/spec/factories/event_date.rb
@@ -16,6 +16,9 @@ FactoryBot.define do
     accept_reservations { 1 }
     accept_interest { 1 }
     published_date_key { (Date.today - 1).to_s.delete('-') }
+    published_end_datetime do
+      (DateTime.current + 1).utc.strftime('%Y-%m-%d %H:%M:%S')
+    end
     added_by { 0 }
     last_update_by { 0 }
 

--- a/spec/models/event_date_spec.rb
+++ b/spec/models/event_date_spec.rb
@@ -58,7 +58,7 @@ describe EventDate, type: :model do
     it 'ignores event dates for events that do not publish dates' do
       event = create(:event, status_publish_event_dates: 0)
       create(:event_date, event: event)
-      DateTime.current.utc.strftime('%Y-%m-%d %H:%M:%S')
+
       expect(described_class.event_publishes_dates).to be_empty
     end
 

--- a/spec/models/event_date_spec.rb
+++ b/spec/models/event_date_spec.rb
@@ -62,12 +62,26 @@ describe EventDate, type: :model do
       expect(described_class.event_publishes_dates).to be_empty
     end
 
-    it 'ignores event dates where current datetime < published_end_datetime' do
+    it 'ignores event dates where current datetime > published_end_datetime' do
       # create event_date with published_end_datetime two days in the past
       create(:event_date, published_end_datetime:
              (DateTime.current - 2).utc.strftime('%Y-%m-%d %H:%M:%S'))
 
-      expect(described_class.end_datetime).to be_empty
+      expect(described_class.active).to be_empty
+    end
+
+    it 'accepts event dates where current datetime == published_end_datetime' do
+      create(:event_date, published_end_datetime:
+             DateTime.current.utc.strftime('%Y-%m-%d %H:%M:%S'))
+
+      expect(described_class.active).not_to be_empty
+    end
+
+    it 'accepts event dates where current datetime < published_end_datetime' do
+      create(:event_date, published_end_datetime:
+             (DateTime.current + 2).utc.strftime('%Y-%m-%d %H:%M:%S'))
+
+      expect(described_class.active).not_to be_empty
     end
   end
 end

--- a/spec/models/event_date_spec.rb
+++ b/spec/models/event_date_spec.rb
@@ -58,8 +58,16 @@ describe EventDate, type: :model do
     it 'ignores event dates for events that do not publish dates' do
       event = create(:event, status_publish_event_dates: 0)
       create(:event_date, event: event)
-
+      DateTime.current.utc.strftime('%Y-%m-%d %H:%M:%S')
       expect(described_class.event_publishes_dates).to be_empty
+    end
+
+    it 'ignores event dates where current datetime < published_end_datetime' do
+      # create event_date with published_end_datetime two days in the past
+      create(:event_date, published_end_datetime:
+             (DateTime.current - 2).utc.strftime('%Y-%m-%d %H:%M:%S'))
+
+      expect(described_class.end_datetime).to be_empty
     end
   end
 end


### PR DESCRIPTION
The EventDate.end_datetime scope omits the display of event_date json objects where the current datetime is greater than the EventDate.published_end_datetime (both datetimes are UTC).  This will prevent users from registering for events in the past.  See Issue #31 for background but note that the issue includes separate scopes for time and date which is now combined into a single datetime.

DEPENDENCY ALERT: This PR cannot be merged to master until PR #41 is merged to master because PR #41 includes the schema.rb and RDS mysql dump that is required for this PR to pass CI.