### PR TITLE
Service param added to agency controller to limit results by service_category

### DIFF
--- a/app/controllers/api/agencies_controller.rb
+++ b/app/controllers/api/agencies_controller.rb
@@ -11,6 +11,9 @@ module Api
       if (@zip = search_params[:zip_code])
         @agencies = @agencies.by_zip_code(@zip)
       end
+      if (@service = search_params[:service])
+        @agencies = @agencies.by_service_category(@service)
+      end
       if (date = search_params[:event_date])
         @agencies = @agencies.with_event_after(date.delete('-'))
       end
@@ -27,12 +30,13 @@ module Api
     private
 
     def search_params
-      params.permit(:zip_code, :event_date, :lat, :long)
+      params.permit(:zip_code, :event_date, :lat, :long, :service)
     end
 
     def set_agencies
       @agencies =
-        if !search_params[:zip_code] && !search_params[:event_date]
+        if !search_params[:zip_code] && !search_params[:event_date] &&
+           !search_params[:service]
           Agency.none
         else
           Agency.distinct

--- a/app/controllers/api/agencies_controller.rb
+++ b/app/controllers/api/agencies_controller.rb
@@ -11,11 +11,11 @@ module Api
       if (@zip = search_params[:zip_code])
         @agencies = @agencies.by_zip_code(@zip)
       end
-      if (@service = search_params[:service])
-        @agencies = @agencies.by_service_category(@service)
-      end
       if (date = search_params[:event_date])
         @agencies = @agencies.with_event_after(date.delete('-'))
+      end
+      if (@service = search_params[:service])
+        @agencies = @agencies.by_service_category(@service)
       end
 
       render json: serialized_agencies
@@ -73,6 +73,7 @@ module Api
       ActiveModelSerializers::SerializableResource.new(@agencies,
                                                        user_location:
                                                        @user_location,
+                                                       service: @service,
                                                        zip_code: @zip)
                                                   .as_json
     end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -3,7 +3,21 @@
 module Api
   # Controller to expose Events
   class EventsController < Api::BaseController
+    before_action :set_events, only: [:index]
+    before_action :set_user_location, only: [:index]
     before_action :set_event, only: [:show]
+
+    def index
+      @events = @events.by_zip_code(@zip) if (@zip = search_params[:zip_code])
+      if (date = search_params[:event_date])
+        @events = @events.with_event_after(date.delete('-'))
+      end
+      if (@service = search_params[:service])
+        @events = @events.by_service_category(@service)
+      end
+
+      render json: serialized_events
+    end
 
     # GET /api/events/:id
     def show
@@ -13,8 +27,50 @@ module Api
 
     private
 
+    def search_params
+      params.permit(:zip_code, :event_date, :lat, :long, :service)
+    end
+
+    def set_events
+      @events =
+        if !search_params[:zip_code] && !search_params[:event_date] &&
+           !search_params[:service]
+          Event.none
+        else
+          Event.distinct
+        end
+    end
+
     def set_event
       @event = Event.find(params[:id])
+    end
+
+    # set_user_location loads the objects used to return distance.
+    # Valid :lat :long parameters will take precedence over the
+    # :zip_code paramter (used to calculate distance from the zip code
+    # (centroid)
+    def set_user_location
+      return unless (search_params[:lat] && search_params[:long]) ||
+                    search_params[:zip_code]
+
+      user_location_object(search_params[:lat], search_params[:long],
+                           search_params[:zip_code])
+    end
+
+    def user_location_object(lat, long, zip_code)
+      if Geo.valid_coordinate(lat, long)
+        @user_location = OpenStruct.new(lat: lat.to_f, long: long.to_f)
+      elsif zip_code
+        @user_location = ZipCode.find_by(zip_code: zip_code)
+      end
+    end
+
+    def serialized_events
+      ActiveModelSerializers::SerializableResource.new(@events,
+                                                       user_location:
+                                                       @user_location,
+                                                       zip_code: @zip)
+                                                  .as_json
     end
   end
 end

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -16,6 +16,7 @@ class Agency < ApplicationRecord
   has_many :event_dates, through: :events,
                          dependent: :restrict_with_exception
   has_many :event_zip_codes, through: :events
+  has_many :service_categories, through: :events
 
   default_scope { active }
 
@@ -39,5 +40,10 @@ class Agency < ApplicationRecord
   scope :by_zip_code, lambda { |zip_code|
     joins(:event_zip_codes)
       .where(event_service_geographies: { geo_value: zip_code })
+  }
+
+  scope :by_service_category, lambda { |service_category|
+    joins(:service_categories)
+      .where(service_categories: { service_category: service_category })
   }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -41,6 +41,16 @@ class Event < ApplicationRecord
     agency.loc_name
   end
 
+  scope :with_event_after, lambda { |date|
+    joins(:event_dates)
+      .where('event_dates.event_date_key >= ?', date)
+  }
+
+  scope :by_zip_code, lambda { |zip_code|
+    joins(:event_zip_codes)
+      .where(event_service_geographies: { geo_value: zip_code })
+  }
+
   scope :by_service_category, lambda { |service_category|
     joins(:service_category)
       .where(service_categories: { service_category: service_category })

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -40,4 +40,9 @@ class Event < ApplicationRecord
   def agency_name
     agency.loc_name
   end
+
+  scope :by_service_category, lambda { |service_category|
+    joins(:service_category)
+      .where(service_categories: { service_category: service_category })
+  }
 end

--- a/app/models/service_category.rb
+++ b/app/models/service_category.rb
@@ -7,5 +7,5 @@ class ServiceCategory < ApplicationRecord
   has_many :service_types, foreign_key: :service_category1,
                            inverse_of: :service_category,
                            dependent: :restrict_with_exception
-  has_many :agencies, through: :event
+  has_many :events, through: :service_types
 end

--- a/app/models/service_category.rb
+++ b/app/models/service_category.rb
@@ -7,4 +7,5 @@ class ServiceCategory < ApplicationRecord
   has_many :service_types, foreign_key: :service_category1,
                            inverse_of: :service_category,
                            dependent: :restrict_with_exception
+  has_many :agencies, through: :event
 end

--- a/app/serializers/agency_serializer.rb
+++ b/app/serializers/agency_serializer.rb
@@ -9,6 +9,16 @@ class AgencySerializer < ActiveModel::Serializer
 
   has_many :events
 
+  def events
+    # required to limit events by agencies controller service param
+    # because agency version of query limits by agencies only
+    if (service = instance_options[:service])
+      return object.events.by_service_category(service)
+    end
+
+    object.events
+  end
+
   def address
     return object.address1 if object.address2.empty?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Jets.application.routes.draw do
       resources :event_hours, only: %i[index show] do
       end
     end
-    resources :events, only: :show
+    resources :events, only: %i[index show]
     resources :foodbanks, only: :index
   end
 

--- a/spec/controllers/api/agencies_controller_spec.rb
+++ b/spec/controllers/api/agencies_controller_spec.rb
@@ -102,6 +102,13 @@ describe Api::AgenciesController, type: :controller do
     expect(response_body).to eq(expected_response(100.1, -190.9, false))
   end
 
+  it 'is indexable by service category' do
+    get '/api/agencies', service: event.service_category.id
+    expect(response.status).to eq 200
+    response_body = JSON.parse(response.body).deep_symbolize_keys
+    expect(response_body).to eq(expected_response(nil, nil, false))
+  end
+
   def expected_response(lat = nil, long = nil, has_zip = true)
     {
       agencies: [

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -31,6 +31,15 @@ describe Agency, type: :model do
     expect(agency.event_zip_codes.pluck(:id)).to eq(event_zip_codes.pluck(:id))
   end
 
+  it 'has service categories' do
+    service_categories = 5.times.map do
+      create(:event, agency: agency).service_category
+    end
+
+    expect(agency.service_categories.pluck(:id))
+      .to eq(service_categories.pluck(:id))
+  end
+
   context 'with scopes' do
     before do
       # default that should be ignored by scopes
@@ -79,6 +88,19 @@ describe Agency, type: :model do
 
       agency_results = described_class.with_event_after(target_date)
       expect(agency_results.pluck(:id)).to eq(expected_agency_ids)
+    end
+
+    it 'can find agencies through a service_category' do
+      service = create(:service_category)
+      agencies = 5.times.map do
+        agency = create(:agency)
+        create(:event, service_category: service, agency: agency)
+        agency
+      end
+
+      agency_results =
+        described_class.by_service_category(service.service_category)
+      expect(agency_results.pluck(:id)).to eq(agencies.pluck(:id))
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -34,6 +34,12 @@ describe Event, type: :model do
     expect(event.agency_name).to eq(event.agency.loc_name)
   end
 
+  it 'has event zip codes' do
+    event_zip_codes = 5.times.map { create(:event_zip_code, event: event) }
+
+    expect(event.event_zip_codes.pluck(:id)).to eq(event_zip_codes.pluck(:id))
+  end
+
   context 'with scopes' do
     it 'defaults to active and published events' do
       create(:event, status_id: 0, status_publish_event: 0)
@@ -58,6 +64,34 @@ describe Event, type: :model do
       events_results =
         described_class.by_service_category(service.service_category)
       expect(events_results.pluck(:id)).to eq(events.pluck(:id))
+    end
+
+    it 'can find events through an event_zip_code' do
+      events = 1.times.map do
+        create(:event)
+      end
+
+      zip = create(:event_zip_code, event_id: events[0].event_id)
+
+      events_results =
+        described_class.by_zip_code(zip.geo_value)
+      expect(events_results.pluck(:id)).to eq(events.pluck(:id))
+    end
+
+    it 'can find events with event dates after a date' do
+      events = 5.times.map do |i|
+        date = (Date.today + i).to_s.delete('-')
+
+        event = create(:event)
+        create(:event_date, event: event, date: date)
+        event
+      end
+
+      target_date = (Date.today + 1).to_s.delete('-')
+      expected_event_ids = events[1..-1].pluck(:id)
+
+      event_results = described_class.with_event_after(target_date)
+      expect(event_results.pluck(:id)).to eq(expected_event_ids)
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -48,5 +48,16 @@ describe Event, type: :model do
       expected_id = event.id
       expect(described_class.publishes_dates.pluck(:id)).to eq([expected_id])
     end
+
+    it 'can find events through a service_category' do
+      service = create(:service_category)
+      events = 5.times.map do
+        create(:event, service_category: service)
+      end
+
+      events_results =
+        described_class.by_service_category(service.service_category)
+      expect(events_results.pluck(:id)).to eq(events.pluck(:id))
+    end
   end
 end


### PR DESCRIPTION
Added "service" query param to the agency controller index method.  This parameter maps to the service_category (primary key of service_categories).  For example limiting an agencies request with a service param of 20 returns only agencies that have events with a service_category_name that corresponds to that service param.  In this case, the service param returns only the agencies that have events with a service_category_name of "Produce".

Note:  This action actually involves two queries.  Agency.by_service_category limits the results to the Agencies that contain at least one event with a matching service_category.  Event.by_service_category limits the results within each Agency to those with a matching service_category.  Event.by_service_category is set up in the Agency serializer.  
```
   has_many :events

   def events
    # required to limit events by agencies controller service param
    # because agency version of query limits by agencies only
    if (service = instance_options[:service])
      return object.events.by_service_category(service)
    end

    object.events
  end
```
The Event version alone will provide the correct results but the performance when just using the service query param is terrible.  Using both queries only adds a few milliseconds when used along with the zip_code param.  Based on these performance results I included both queries in the action.

Example request

http://localhost:8888/api/agencies?service=20

Example response (truncated)

<pre>
{
    "agencies": [
        {
            "id": 12,
            "address": "15500 S WATERLOO RD",
            "city": "CLEVELAND",
            "state": "OH",
            "zip": "44110",
            "phone": "216.738.2265",
            "name": "Greater Cleveland Food Bank",
            "nickname": "Greater Cleveland Food Bank",
            "estimated_distance": "",
            "events": [
                {
                    "id": 42,
                    "address": "15500 S WATERLOO RD ",
                    "city": "CLEVELAND",
                    "state": "OH",
                    "zip": "44110",
                    "agency_id": 12,
                    "latitude": "41.5669006",
                    "longitude": "-81.5724759",
                    "name": "MOBILE PAN",
                    "service": "Produce",
                    "estimated_distance": "",
                    "exception_note": "",
                    "event_details": "",
                    "agency_name": "Greater Cleveland Food Bank",
                    "event_dates": [],
                    "forms": [
                        {
                            "id": 91,
                            "display_age_adult": 18,
                            "display_age_senior": 60
                        }
                    ]
                }
            ]
        },
        {
            "id": 1362,
            "address": "301 N Main",
            "city": "BETHESDA",
            "state": "OH",
            "zip": "43719",
            "phone": "740-298-0076",
            "name": "Belmont Mobile Market",
            "nickname": "Union Local Schools",
            "estimated_distance": "",
            "events": [
                {
                    "id": 1993,
                    "address": "301 N Main  ",
                    "city": "BETHESDA",
                    "state": "OH",
                    "zip": "43719",
                    "agency_id": 1362,
                    "latitude": "40.0185289",
                    "longitude": "-81.07400753",
                    "name": "Mobile Market",
                    "service": "Produce",
                    "estimated_distance": "",
                    "exception_note": "",
                    "event_details": "",
                    "agency_name": "Belmont Mobile Market",
                    "event_dates": [
                        {
                            "id": 7418,
                            "event_id": 1993,
                            "capacity": 10,
                            "accept_walkin": 1,
                            "accept_reservations": 0,
                            "accept_interest": 0,
                            "start_time": "10 AM",
                            "end_time": "12 PM",
                            "date": "2020-08-06"
                        },
                        {
                            "id": 7419,
                            "event_id": 1993,
                            "capacity": 10,
                            "accept_walkin": 1,
                            "accept_reservations": 0,
                            "accept_interest": 0,
                            "start_time": "10 AM",
                            "end_time": "12 PM",
                            "date": "2020-08-20"
                        }
                    ],
                    "forms": [
                        {
                            "id": 91,
                            "display_age_adult": 18,
                            "display_age_senior": 60
                        }
                    ]
                }
            ]
        }
    ...
</pre>