### PR TITLE
added service_category serializer

### DIFF
--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -13,6 +13,7 @@ class EventSerializer < ActiveModel::Serializer
 
   has_many :event_dates
   has_many :forms
+  has_one :service_category
 
   def address
     return object.address1 if object.address2.nil?

--- a/app/serializers/service_category_serializer.rb
+++ b/app/serializers/service_category_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Defines service_category, attributes to be returned in JSON
+class ServiceCategorySerializer < ApplicationSerializer
+  attribute :id
+  attribute :service_category_name
+end

--- a/spec/controllers/api/agencies_controller_spec.rb
+++ b/spec/controllers/api/agencies_controller_spec.rb
@@ -154,7 +154,13 @@ describe Api::AgenciesController, type: :controller do
                   display_age_adult: form.max_age_child + 1,
                   display_age_senior: form.max_age_adult + 1
                 }
-              ]
+              ],
+              service_category:
+                {
+                  id: event.service_category.id,
+                  service_category_name:
+                    event.service_category.service_category_name
+                }
             }
           ]
         }


### PR DESCRIPTION
Adding a serializer to match the service_category model.  Note: This will deprecate the "service" field in the event JSON.  The "service" field will remain for backward compatibility until the corresponding UI changes are released.

example request:

http://localhost:8888/api/events/3699

example response:

<pre>
{
    "event": {
        "id": 3699,
        "address": "966 E MAIN ST  ",
        "city": "COLUMBUS",
        "state": "OH",
        "zip": "43205",
        "agency_id": 502,
        "latitude": "39.95800777",
        "longitude": "-82.97354855",
        "name": "Fresh Produce Only ",
        "service": "Produce",
        "estimated_distance": "",
        "exception_note": "",
        "event_details": "Hands On Appointment Recommended",
        "agency_name": "Salvation Army East Main Choice FP ",
        "event_dates": [],
        "forms": [
            {
                "id": 91,
                "display_age_adult": 18,
                "display_age_senior": 60
            }
        ],
        "service_category": {
            "id": 20,
            "service_category_name": "Produce"
        }
    }
}
</pre>

