### PR TITLE
remove service attribute from event serializers

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,10 +21,6 @@ class Event < ApplicationRecord
   scope :published, -> { where(status_publish_event: 1) }
   scope :publishes_dates, -> { where(status_publish_event_dates: 1) }
 
-  def service_description
-    service_category.service_category_name
-  end
-
   def exception_note(zip_code)
     # if zip_code parameter submitted use it, otherwise use event.zip
     event_zip = if zip_code

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -7,7 +7,6 @@ class EventSerializer < ActiveModel::Serializer
   attribute :pt_latitude, key: :latitude
   attribute :pt_longitude, key: :longitude
   attribute :event_name, key: :name
-  attribute :service_description, key: :service
   attributes :estimated_distance, :exception_note, :event_details
   attribute  :agency_name
 

--- a/spec/controllers/api/agencies_controller_spec.rb
+++ b/spec/controllers/api/agencies_controller_spec.rb
@@ -128,7 +128,6 @@ describe Api::AgenciesController, type: :controller do
               longitude: event.pt_longitude.to_f.to_s,
               agency_id: event.loc_id,
               name: event.event_name,
-              service: event.service_description,
               estimated_distance: Geo.distance_between(
                 OpenStruct.new(lat: lat, long: long), event
               ),

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -26,10 +26,6 @@ describe Event, type: :model do
     expect(event.forms.pluck(:id)).to eq(forms.pluck(:id))
   end
 
-  it 'has a service description' do
-    expect(event.service_description).to eq('Choice Pantry')
-  end
-
   it 'has an agency name' do
     expect(event.agency_name).to eq(event.agency.loc_name)
   end


### PR DESCRIPTION
remove service attribute from event serializers


note: we deprecate the "service" field in the event JSON & added ``"service_category": {
    "id": 10,
    "service_category_name": "Choice Pantry"
}`` through PR-45  to match the service_category model.