### PR TITLE
added active scope and test for foodbank_text model

### DIFF
--- a/app/models/foodbank_text.rb
+++ b/app/models/foodbank_text.rb
@@ -3,5 +3,9 @@
 # Foodbank, associated to many Foodbank Texts
 class FoodbankText < ApplicationRecord
   self.table_name = 'fb_text'
+
   belongs_to :foodbank, foreign_key: :fb_id, inverse_of: :foodbank_texts
+
+  default_scope { active }
+  scope :active, -> { where(status_id: 1) }
 end

--- a/spec/factories/foodbank_text.rb
+++ b/spec/factories/foodbank_text.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     date_added { 'CURRENT_TIMESTAMP' }
     added_by { 0 }
     status_id { 1 }
-    text { Faker::Name.name }
-    link_text { Faker::Name.name }
+    text { Faker::Lorem.paragraph }
+    link_text { Faker::Lorem.paragraph }
     link_href { Faker::Internet.url }
     image_resource { Faker::Internet.url }
     foodbank

--- a/spec/models/foodbank_text_spec.rb
+++ b/spec/models/foodbank_text_spec.rb
@@ -3,7 +3,16 @@
 describe FoodbankText, type: :model do
   let(:foodbank_text) { create(:foodbank_text) }
 
-  it 'association for fb text' do
+  it 'association for foodbank text' do
     expect(foodbank_text.foodbank).to be_an_instance_of(Foodbank)
+  end
+
+  context 'with scopes' do
+    it 'defaults to active foodbank_texts' do
+      active = create(:foodbank_text, status_id: 1)
+      create(:foodbank_text, status_id: 0)
+      expected_id = active.id
+      expect(described_class.all.pluck(:id)).to eq([expected_id])
+    end
   end
 end


### PR DESCRIPTION

Closes #54 

Added active scope where(status_id: 1) to foodbank_text model.
Added scope test to foodbank_text_spec.rb
Changed Faker::Name.name to Faker::Lorem.paragraph in foodbank_text factory.  This produces a small latin paragraph which is commonly used to indicate text.

example: "Quod ducimus repudiandae. Qui rem temporibus. Maiores labore eos."
