### PR TITLE
EventDate validation error handling  and rspec tests

### DIFF
--- a/app/controllers/api/event_dates_controller.rb
+++ b/app/controllers/api/event_dates_controller.rb
@@ -7,20 +7,23 @@ module Api
 
     # GET /api/event_dates/:id
     def show
-      if @event_date.valid?
-        render json:
-          ActiveModelSerializers::SerializableResource.new(
-            @event_date, event_hours: true, event_slots: true
-          ).as_json
-      else
-        render json: { errors: @event_date.errors }
-      end
+      render json:
+        ActiveModelSerializers::SerializableResource.new(
+          @event_date, event_hours: true, event_slots: true
+        ).as_json
     end
 
     private
 
     def set_event_date
-      @event_date = EventDate.find(params[:event_date_id])
+      # unscope to handle scoped validation errors
+      @event_date = EventDate.unscoped.find(params[:event_date_id])
+      if @event_date.valid?
+        # perform unscoped find to catch record_not_found exception
+        EventDate.find(params[:event_date_id])
+      else
+        render json: { errors: @event_date.errors }
+      end
     end
   end
 end

--- a/app/lib/error/error_handler.rb
+++ b/app/lib/error/error_handler.rb
@@ -21,7 +21,7 @@ module Error
 
     def capture_record_id(msg)
       regex = Regexp.new('(.*?)\[', Regexp::IGNORECASE)
-      return unless (matches = msg.as_json.match(regex))
+      return msg unless (matches = msg.as_json.match(regex))
 
       matches[1].strip
     end

--- a/app/models/event_date.rb
+++ b/app/models/event_date.rb
@@ -37,6 +37,6 @@ class EventDate < ApplicationRecord
   end
 
   def still_open?
-    DateTime.current < published_end_datetime
+    DateTime.current.utc.strftime('%Y-%m-%d %H:%M:%S') <= published_end_datetime
   end
 end

--- a/app/validators/event_date_validator.rb
+++ b/app/validators/event_date_validator.rb
@@ -12,18 +12,24 @@ class EventDateValidator < ActiveModel::Validator
   def published?(record)
     return if record.published?
 
-    record.errors.add(:event_date, 'event is not published')
+    record.errors.add(:event_date,
+                      { code: 1001,
+                        message: 'event is not published' })
   end
 
   def capacity?(record)
     return if record.open_slots.positive?
 
-    record.errors.add(:event_date, 'event is at capacity')
+    record.errors.add(:event_date,
+                      { code: 1002,
+                        message: 'event is at capacity' })
   end
 
   def still_open?(record)
     return if record.still_open?
 
-    record.errors.add(:event_date, 'event expired and reservations closed')
+    record.errors.add(:event_date,
+                      { code: 1003,
+                        message: 'event expired and reservations closed' })
   end
 end

--- a/spec/controllers/api/event_dates_controller_spec.rb
+++ b/spec/controllers/api/event_dates_controller_spec.rb
@@ -20,4 +20,31 @@ describe Api::EventDatesController, type: :controller do
     expect(event_date_response['error']).to eq('record_not_found')
     expect(event_date_response['message']).not_to be(nil)
   end
+
+  it 'returns validaton error message when event_date is expired' do
+    expired_event_date =
+      build(:event_date, service_id: 10, published_end_datetime:
+      (DateTime.current - 2).utc.strftime('%Y-%m-%d %H:%M:%S'))
+    expired_event_date.save(validate: false)
+
+    get "api/event_dates/#{expired_event_date.event_date_id}"
+    record = JSON.parse(response.body)
+
+    expect(record['errors']['event_date'][0]['code']).to eq(1003)
+    expect(record['errors']['event_date'][0]['message']).not_to be(nil)
+  end
+
+  it 'returns multiple validaton error messages' do
+    event_date =
+      build(:event_date, capacity: 50, reserved: 50,
+                         service_id: 10, status_publish: 0,
+                         published_date_key:
+                         (Date.today - 2).to_s.delete('-'))
+    event_date.save(validate: false)
+
+    get "api/event_dates/#{event_date.event_date_id}"
+    record = JSON.parse(response.body)
+
+    expect(record['errors']['event_date'].count).to eq(2)
+  end
 end

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -10,4 +10,12 @@ describe Api::EventsController, type: :controller do
     event_response = JSON.parse(response.body)['event']
     expect(event_response['id']).to eq(event.id)
   end
+
+  it 'returns error message when event_date is not found in database' do
+    get 'api/events/-404'
+    event_response = JSON.parse(response.body)
+    expect(event_response['status']).to eq(404)
+    expect(event_response['error']).to eq('record_not_found')
+    expect(event_response['message']).not_to be(nil)
+  end
 end


### PR DESCRIPTION
Request to merge into PR #57

- Wired up event_date controller to successfully render the three event_date validation errors already specified
- Added error code to validation errors to be machine and rspec friendly
- Added rspec test cases for individual and multiple validation errors.
- Added rspec test for events_controller 404 record not found

Example request and response for an expired event_date

http://localhost:8888/api/event_dates/2528

<pre>
{
    "errors": {
        "event_date": [
            {
                "code": 1003,
                "message": "event expired and reservations closed"
            }
        ]
    }
}
</pre>