### PR TITLE
event_date_id param and scope

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -3,7 +3,16 @@
 module Api
   # Controller to expose Events
   class EventsController < Api::BaseController
+    before_action :set_events, only: [:index]
     before_action :set_event, only: [:show]
+
+    def index
+      if (@event_date_id = search_params[:event_date_id])
+        @events = @events.with_event_date_id(@event_date_id)
+      end
+
+      render json: serialized_events
+    end
 
     # GET /api/events/:id
     def show
@@ -13,8 +22,25 @@ module Api
 
     private
 
+    def search_params
+      params.permit(:event_date_id)
+    end
+
+    def set_events
+      @events =
+        if !search_params[:event_date_id]
+          Event.none
+        else
+          Event.distinct
+        end
+    end
+
     def set_event
       @event = Event.find(params[:id])
+    end
+
+    def serialized_events
+      ActiveModelSerializers::SerializableResource.new(@events).as_json
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -41,4 +41,6 @@ class Event < ApplicationRecord
   def agency_name
     agency.loc_name
   end
+
+  delegate :phone, to: :agency, prefix: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,6 +21,11 @@ class Event < ApplicationRecord
   scope :published, -> { where(status_publish_event: 1) }
   scope :publishes_dates, -> { where(status_publish_event_dates: 1) }
 
+  scope :with_event_date_id, lambda { |event_date_id|
+    joins(:event_dates)
+      .where('event_dates.event_date_id = ?', event_date_id)
+  }
+
   def exception_note(zip_code)
     # if zip_code parameter submitted use it, otherwise use event.zip
     event_zip = if zip_code

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -8,7 +8,7 @@ class EventSerializer < ActiveModel::Serializer
   attribute :pt_longitude, key: :longitude
   attribute :event_name, key: :name
   attributes :estimated_distance, :exception_note, :event_details
-  attribute  :agency_name
+  attributes :agency_name, :agency_phone
 
   has_many :event_dates
   has_many :forms

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Jets.application.routes.draw do
         get :event_details
       end
     end
-    resources :events, only: :show
+    resources :events, only: %i[index show]
     resources :foodbanks, only: :index
   end
 

--- a/spec/controllers/api/agencies_controller_spec.rb
+++ b/spec/controllers/api/agencies_controller_spec.rb
@@ -134,6 +134,7 @@ describe Api::AgenciesController, type: :controller do
               exception_note: has_zip ? event_geography.exception_note : '',
               event_details: event.pub_desc_long,
               agency_name: agency.loc_name,
+              agency_phone: agency.phone,
               event_dates: [
                 {
                   id: event_date.id,

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -18,4 +18,12 @@ describe Api::EventsController, type: :controller do
     expect(event_response['error']).to eq('record_not_found')
     expect(event_response['message']).not_to be(nil)
   end
+
+  it 'is indexable by event_date_id' do
+    event_date = create(:event_date, event: event)
+    get '/api/events', event_date_id: event_date.id
+    expect(response.status).to eq 200
+    response_body = JSON.parse(response.body)
+    expect(response_body['events'].count).to eq(1)
+  end
 end

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -27,8 +27,8 @@ describe Api::EventsController, type: :controller do
     expect(response_body['events'].count).to eq(1)
   end
 
-  it 'it returns no results without parameters' do
-    event_date = create(:event_date, event: event)
+  it 'returns no results without parameters' do
+    create(:event_date, event: event)
     get '/api/events'
     expect(response.status).to eq 200
     response_body = JSON.parse(response.body)

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -26,4 +26,12 @@ describe Api::EventsController, type: :controller do
     response_body = JSON.parse(response.body)
     expect(response_body['events'].count).to eq(1)
   end
+
+  it 'it returns no results without parameters' do
+    event_date = create(:event_date, event: event)
+    get '/api/events'
+    expect(response.status).to eq 200
+    response_body = JSON.parse(response.body)
+    expect(response_body['events'].count).to eq(0)
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -30,6 +30,10 @@ describe Event, type: :model do
     expect(event.agency_name).to eq(event.agency.loc_name)
   end
 
+  context 'when delegating methods to agency object' do
+    it { is_expected.to respond_to(:agency_phone) }
+  end
+
   context 'with scopes' do
     it 'defaults to active and published events' do
       create(:event, status_id: 0, status_publish_event: 0)
@@ -43,6 +47,18 @@ describe Event, type: :model do
       create(:event, status_publish_event_dates: 0)
       expected_id = event.id
       expect(described_class.publishes_dates.pluck(:id)).to eq([expected_id])
+    end
+
+    it 'can find an event with a specific event_date' do
+      event_date = create(:event_date, event: event)
+      expect(described_class.with_event_date_id(event_date.id).pluck(:id))
+        .to eq([event.id])
+    end
+
+    it 'cannot cannot find an event with a specific event_date' do
+      create(:event_date, event: event)
+      expect(described_class.with_event_date_id(-500).pluck(:id))
+        .not_to eq([event.id])
     end
   end
 end


### PR DESCRIPTION
Added an event_date_id parameter on the events endpoint.  The response returns the event containing the event_date represented by the event_date_id.

Example request:

http://localhost:8888/api/events?event_date_id=16195 

Example response:

<pre>
{
    "events": [
        {
            "id": 5596,
            "address": "3960 BROOKHAM DR  ",
            "city": "GROVE CITY",
            "state": "OH",
            "zip": "43123",
            "agency_id": 6,
            "latitude": "39.8862352",
            "longitude": "-83.05538713",
            "name": "Drive Thru Wednesday Evening",
            "estimated_distance": "",
            "exception_note": "",
            "event_details": "This is a drive thru distribution. Wear a mask and make sure your trunk is cleaned out. Please, no more than 5 families being served per vehicle. Please pre-register on FreshTrak.com.",
            "agency_name": "Mid-Ohio Foodbank - Kroger Community Pantry",
            "agency_phone": "614-317-9487",
            "event_dates": [
                {
                    "id": 16194,
                    "event_id": 5596,
                    "capacity": 300,
                    "accept_walkin": 1,
                    "accept_reservations": 0,
                    "accept_interest": 1,
                    "start_time": "5 PM",
                    "end_time": "7 PM",
                    "date": "2020-11-04"
                },
                {
                    "id": 16195,
                    "event_id": 5596,
                    "capacity": 300,
                    "accept_walkin": 1,
                    "accept_reservations": 0,
                    "accept_interest": 1,
                    "start_time": "5 PM",
                    "end_time": "7 PM",
                    "date": "2020-11-11"
                },
                {
                    "id": 16196,
                    "event_id": 5596,
                    "capacity": 300,
                    "accept_walkin": 1,
                    "accept_reservations": 0,
                    "accept_interest": 1,
                    "start_time": "5 PM",
                    "end_time": "7 PM",
                    "date": "2020-11-18"
                },
                {
                    "id": 16197,
                    "event_id": 5596,
                    "capacity": 300,
                    "accept_walkin": 1,
                    "accept_reservations": 0,
                    "accept_interest": 1,
                    "start_time": "5 PM",
                    "end_time": "7 PM",
                    "date": "2020-11-25"
                }
            ],
            "forms": [
                {
                    "id": 91,
                    "display_age_adult": 18,
                    "display_age_senior": 60
                }
            ],
            "service_category": {
                "id": 15,
                "service_category_name": "Prepack Pantry"
            }
        }
    ]
}
</pre>


