### PR TITLE
filter events by service_category (on zip code search)

### DIFF
--- a/app/controllers/api/agencies_controller.rb
+++ b/app/controllers/api/agencies_controller.rb
@@ -15,7 +15,11 @@ module Api
 
       with_event_after(@event_date)
 
-      render json: serialized_agencies
+      if @agencies.blank?
+        render json: {}
+      else
+        render json: serialized_agencies
+      end
     end
 
     # GET /api/agencies/:id
@@ -27,11 +31,11 @@ module Api
     private
 
     def permit_params
-      params.permit(
-        :zip_code, :distance, :event_date, :event_date_on, :lat, :long
-      ).tap do |param|
+      params.permit(:zip_code, :distance, :category,
+                    :event_date, :event_date_on, :lat, :long).tap do |param|
         @zip = param[:zip_code]
         @distance = param[:distance]
+        @category = param[:category]
         @event_date = param[:event_date]
         @lat = param[:lat]
         @long = param[:long]
@@ -40,7 +44,7 @@ module Api
 
     def set_agencies
       @agencies =
-        if !@zip && !@distance && !@event_date
+        if !@zip && !@distance && !@event_date && !@category
           Agency.none
         else
           Agency.distinct
@@ -75,7 +79,8 @@ module Api
       ActiveModelSerializers::SerializableResource.new(@agencies,
                                                        user_location:
                                                        @user_location,
-                                                       zip_code: @zip)
+                                                       zip_code: @zip,
+                                                       category: @category)
                                                   .as_json
     end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,6 +31,11 @@ class Event < ApplicationRecord
       .where(event_service_geographies: { geo_value: zip_code })
   }
 
+  scope :by_service_category, lambda { |service_category|
+    joins(:service_category)
+      .where(service_categories: { service_category_name: service_category })
+  }
+
   def exception_note(zip_code)
     # if zip_code parameter submitted use it, otherwise use event.zip
     event_zip = if zip_code

--- a/app/serializers/agency_serializer.rb
+++ b/app/serializers/agency_serializer.rb
@@ -28,8 +28,13 @@ class AgencySerializer < ActiveModel::Serializer
 
   def events
     zip_code = @instance_options[:zip_code]
-    return object.events if zip_code.nil?
-
-    object.events.by_zip_code(zip_code)
+    category = @instance_options[:category]
+    if zip_code && category
+      object.events.by_zip_code(zip_code).by_service_category(category)
+    elsif zip_code
+      object.events.by_zip_code(zip_code)
+    else
+      object.events
+    end
   end
 end

--- a/spec/controllers/api/agencies_controller_spec.rb
+++ b/spec/controllers/api/agencies_controller_spec.rb
@@ -39,7 +39,7 @@ describe Api::AgenciesController, type: :controller do
     get '/api/agencies'
     expect(response.status).to eq 200
     response_body = JSON.parse(response.body)
-    expect(response_body['agencies']).to be_empty
+    expect(response_body).to be_empty
   end
 
   it 'is indexable by zip_code' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -55,10 +55,23 @@ describe Event, type: :model do
         .to eq([event.id])
     end
 
-    it 'cannot cannot find an event with a specific event_date' do
+    it 'cannot find an event with a specific event_date' do
       create(:event_date, event: event)
       expect(described_class.with_event_date_id(-500).pluck(:id))
         .not_to eq([event.id])
+    end
+
+    it 'can find an event with a specific Service Category' do
+      serv_type = event.service_type
+      service_category_name = serv_type.service_category[:service_category_name]
+      expect(described_class.by_service_category(service_category_name))
+        .to eq([event])
+    end
+
+    it 'cannot find an event with a wrong Service Category' do
+      service_category_name = 'Produce'
+      expect(described_class.by_service_category(service_category_name))
+        .to eq([])
     end
   end
 end


### PR DESCRIPTION
able to Filter Events by Service Category Type.

updated API - 
Example:
http://localhost:8888/api/agencies?zip_code=45622&distance=50&category=Produce

<img width="1440" alt="1_Screen Shot 2021-01-29 at 8 47 44 AM" src="https://user-images.githubusercontent.com/20909776/106282722-fc7c4980-620e-11eb-8b0f-5aad986898dc.png">
