### PR TITLE
zip code controller

### DIFF
--- a/app/controllers/api/zip_codes_controller.rb
+++ b/app/controllers/api/zip_codes_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Api
+  # Exposes the zip_code data
+  class ZipCodesController < Api::BaseController
+    def index
+      zip_codes = ZipCode.by_zip_code(search_params)
+      serialized_zip_codes =
+        ActiveModelSerializers::SerializableResource.new(zip_codes).as_json
+
+      if zip_codes.blank?
+        render json: {}
+      else
+        render json: serialized_zip_codes
+      end
+    end
+
+    private
+
+    def search_params
+      params.require(:zip_code)
+    end
+  end
+end

--- a/app/models/zip_code.rb
+++ b/app/models/zip_code.rb
@@ -10,4 +10,8 @@ class ZipCode < ApplicationRecord
 
   default_scope { active }
   scope :active, -> { where(priority: 1) }
+
+  scope :by_zip_code, lambda { |zip_code|
+    where({ zip_code: zip_code })
+  }
 end

--- a/app/serializers/agency_serializer.rb
+++ b/app/serializers/agency_serializer.rb
@@ -5,8 +5,7 @@ class AgencySerializer < ActiveModel::Serializer
   attributes :id, :address, :city, :state, :zip, :phone
   attribute :loc_name, key: :name
   attribute :loc_nickname, key: :nickname
-  attribute :pt_latitude, key: :latitude
-  attribute :pt_longitude, key: :longitude
+  attributes :latitude, :longitude
   attribute :estimated_distance
 
   has_many :events

--- a/app/serializers/agency_serializer.rb
+++ b/app/serializers/agency_serializer.rb
@@ -5,6 +5,8 @@ class AgencySerializer < ActiveModel::Serializer
   attributes :id, :address, :city, :state, :zip, :phone
   attribute :loc_name, key: :name
   attribute :loc_nickname, key: :nickname
+  attribute :pt_latitude, key: :latitude
+  attribute :pt_longitude, key: :longitude
   attribute :estimated_distance
 
   has_many :events

--- a/app/serializers/zip_code_serializer.rb
+++ b/app/serializers/zip_code_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Defines ZipCode, attributes to be returned in JSON
+class ZipCodeSerializer < ApplicationSerializer
+  attributes :id, :zip_code, :latitude, :longitude
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Jets.application.routes.draw do
     end
     resources :events, only: %i[index show]
     resources :foodbanks, only: :index
+    resources :zip_codes, only: :index
   end
 
   root 'jets/public#show'

--- a/spec/controllers/api/agencies_controller_spec.rb
+++ b/spec/controllers/api/agencies_controller_spec.rb
@@ -121,8 +121,8 @@ describe Api::AgenciesController, type: :controller do
           phone: agency.phone,
           name: agency.loc_name,
           nickname: agency.loc_nickname,
-          latitude: agency.pt_latitude.to_f.to_s,
-          longitude: agency.pt_longitude.to_f.to_s,
+          latitude: agency.latitude.to_f.to_s,
+          longitude: agency.longitude.to_f.to_s,
           estimated_distance: Geo.distance_between(
             OpenStruct.new(lat: lat, long: long), agency
           ),

--- a/spec/controllers/api/agencies_controller_spec.rb
+++ b/spec/controllers/api/agencies_controller_spec.rb
@@ -121,6 +121,8 @@ describe Api::AgenciesController, type: :controller do
           phone: agency.phone,
           name: agency.loc_name,
           nickname: agency.loc_nickname,
+          latitude: agency.pt_latitude.to_f.to_s,
+          longitude: agency.pt_longitude.to_f.to_s,
           estimated_distance: Geo.distance_between(
             OpenStruct.new(lat: lat, long: long), agency
           ),

--- a/spec/controllers/api/zip_codes_controller_spec.rb
+++ b/spec/controllers/api/zip_codes_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Api::ZipCodesController, type: :controller do
+  let(:zip_code) { create(:zip_code) }
+
+  before do
+    create(:zip_code)
+  end
+
+  it 'is indexable by zip_code' do
+    get '/api/zip_codes', zip_code: zip_code.zip_code
+    expect(response.status).to eq 200
+    response_body = JSON.parse(response.body)
+    expect(response_body['zip_codes'].count).to eq(1)
+  end
+
+  it 'returns {} when no zip codes found' do
+    get '/api/zip_codes', zip_code: 99_999
+    expect(response.status).to eq 200
+    response_body = JSON.parse(response.body)
+    expect(response_body).to eq({})
+  end
+end

--- a/spec/serializers/agency_serializer_spec.rb
+++ b/spec/serializers/agency_serializer_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+describe AgencySerializer do
+  context 'with attributes' do
+    let(:zip_code) do
+      create(:zip_code, zip_code: 43_219, latitude: 40.01310,
+                        longitude: -82.92363)
+    end
+    let(:service_category) { create(:service_category) }
+    let(:date) { (Date.today + 5).to_s }
+    let(:agency) { create(:agency) }
+    let(:event) do
+      create(:event, agency: agency, event_address_status_id: 0,
+                     form_master_num: form.form_master_num)
+    end
+    let(:form) { create(:form) }
+    let(:event_geography) { create(:event_geography, exception_note: '') }
+    # let!(:event_zip_code) do
+    # end
+    let!(:event_date) do
+      create(:event_date, event: event, date: date.delete('-'),
+                          start_time_key: 930, end_time_key: 2200)
+    end
+
+    before do
+      create(:event_zip_code, event: event, zip_code: zip_code.zip_code,
+                              event_geography: event_geography)
+    end
+
+    it 'json without user_location, zip_code, category' do
+      serialized_object = JSON.parse(described_class.new(agency).to_json)
+      serialized_object.should == expected_response
+    end
+
+    it 'json with user_location, zip_code, category' do
+      serialized_object2 = JSON.parse(
+        described_class.new(
+          agency, user_location: zip_code, zip_code: zip_code.zip_code,
+                  category: service_category.service_category_name
+        ).to_json
+      )
+      serialized_object2.should == expected_response1
+    end
+
+    def expected_response
+      {
+        'id' => agency.id,
+        'address' => "#{agency.address1} #{agency.address2}",
+        'city' => agency.city,
+        'state' => agency.state,
+        'zip' => agency.zip,
+        'phone' => agency.phone,
+        'name' => agency.loc_name,
+        'nickname' => agency.loc_nickname,
+        'latitude' => agency.latitude.to_f.to_s,
+        'longitude' => agency.longitude.to_f.to_s,
+        'estimated_distance' => '',
+        'events' => [
+          {
+            'id' => event.id,
+            'address' => "#{event.address1} #{event.address2}",
+            'city' => event.city,
+            'state' => event.state,
+            'zip' => event.zip,
+            'agency_id' => event.loc_id,
+            'latitude' => event.pt_latitude.to_f.to_s,
+            'longitude' => event.pt_longitude.to_f.to_s,
+            'name' => event.event_name,
+            'estimated_distance' => '',
+            'exception_note' => '',
+            'event_details' => event.pub_desc_long,
+            'agency_name' => event.agency_name,
+            'agency_phone' => event.agency_phone,
+            'event_dates' => [
+              {
+                'id' => event_date.id,
+                'event_id' => event_date.event_id,
+                'capacity' => event_date.capacity,
+                'accept_walkin' => event_date.accept_walkin,
+                'accept_reservations' => event_date.accept_reservations,
+                'accept_interest' => event_date.accept_interest,
+                'start_time' => '9:30 AM',
+                'end_time' => '10 PM',
+                'date' => date
+              }
+            ],
+            'forms' => [
+              {
+                'id' => form.id,
+                'display_age_adult' => form.display_age_adult,
+                'display_age_senior' => form.display_age_senior
+              }
+            ],
+            'service_category' => {
+              'id' => event.service_category.id,
+              'service_category_name' =>
+                event.service_category.service_category_name
+            }
+          }
+        ]
+      }
+    end
+
+    def expected_response1
+      {
+        'id' => agency.id,
+        'address' => "#{agency.address1} #{agency.address2}",
+        'city' => agency.city,
+        'state' => agency.state,
+        'zip' => agency.zip,
+        'phone' => agency.phone,
+        'name' => agency.loc_name,
+        'nickname' => agency.loc_nickname,
+        'latitude' => agency.latitude.to_f.to_s,
+        'longitude' => agency.longitude.to_f.to_s,
+        'estimated_distance' => '',
+        'events' => [
+          {
+            'id' => event.id,
+            'address' => "#{event.address1} #{event.address2}",
+            'city' => event.city,
+            'state' => event.state,
+            'zip' => event.zip,
+            'agency_id' => event.loc_id,
+            'latitude' => event.pt_latitude.to_f.to_s,
+            'longitude' => event.pt_longitude.to_f.to_s,
+            'name' => event.event_name,
+            'estimated_distance' => event.estimated_distance(zip_code),
+            'exception_note' => '',
+            'event_details' => event.pub_desc_long,
+            'agency_name' => event.agency_name,
+            'agency_phone' => event.agency_phone,
+            'event_dates' => [
+              {
+                'id' => event_date.id,
+                'event_id' => event_date.event_id,
+                'capacity' => event_date.capacity,
+                'accept_walkin' => event_date.accept_walkin,
+                'accept_reservations' => event_date.accept_reservations,
+                'accept_interest' => event_date.accept_interest,
+                'start_time' => '9:30 AM',
+                'end_time' => '10 PM',
+                'date' => date
+              }
+            ],
+            'forms' => [
+              {
+                'id' => form.id,
+                'display_age_adult' => form.display_age_adult,
+                'display_age_senior' => form.display_age_senior
+              }
+            ],
+            'service_category' => {
+              'id' => event.service_category.id,
+              'service_category_name' =>
+                event.service_category.service_category_name
+            }
+          }
+        ]
+      }
+    end
+  end
+end


### PR DESCRIPTION
Created a zip_codes controller in order to retrieve zip code centroids to be used in centering agency map views.  Also added latitude and longitude elements to agencies JSON response to distinguish from event geolocation.

Example Request:

http://localhost:8888/api/zip_codes?zip_code=43130

Example Response:
```
{
  "zip_codes": [
  {
    "id": 49946,
    "zip_code": "43130",
    "latitude": "39.7208",
    "longitude": "-82.6044"
  }
]
}
```

Note: The first use case is an external heroku web app that I am working on PN.