### PR TITLE
Fix distance filtering when using lat/long coordinates

### DIFF
--- a/app/controllers/api/agencies_controller.rb
+++ b/app/controllers/api/agencies_controller.rb
@@ -91,7 +91,7 @@ module Api
     end
 
     def by_zip_and_distance
-      return unless @zip && @distance
+      return unless @user_location && @distance
 
       agencies = filter_agencies_by_location
       agencies_by_event = filter_agencies_by_event_location

--- a/spec/controllers/api/agencies_controller_spec.rb
+++ b/spec/controllers/api/agencies_controller_spec.rb
@@ -74,6 +74,13 @@ describe Api::AgenciesController, type: :controller do
     expect(response_body).to eq(expected_response(zip_code.lat, zip_code.long))
   end
 
+  it 'is indexable by lat/long and distance' do
+    get '/api/agencies', lat: event.lat.to_s, long: event.long.to_s, distance: '10'
+    expect(response.status).to eq 200
+    response_body = JSON.parse(response.body).deep_symbolize_keys
+    expect(response_body).to eq(expected_response(event.lat, event.long))
+  end
+
   it 'is indexable by zip_code and includes lat & long params' do
     get '/api/agencies', zip_code: event_zip_code.zip_code, lat: event.lat.to_s,
                          long: event.long.to_s


### PR DESCRIPTION
## Fix distance filtering when using lat/long coordinates

Fixes #132

### Problem
The `/api/agencies` endpoint was not applying distance filtering when using latitude/longitude coordinates. The API would return all agencies regardless of the distance parameter when called like:
```
GET /api/agencies?lat=35.2029&long=-122.6588&distance=5
```

### Root Cause
The `by_zip_and_distance` method in `AgenciesController` only executed when both `@zip` AND `@distance` were present. When users provided lat/long coordinates instead of a zip code, the distance filtering logic was completely bypassed.

### Solution
Changed the condition from checking `@zip && @distance` to `@user_location && @distance`. The `@user_location` variable is populated from either:
- Zip code lookup (existing behavior)
- Lat/long coordinates (now fixed)

This ensures distance filtering works correctly for both input methods.

### Testing
- Added a new test case `is indexable by lat/long and distance` to verify the fix
- The test follows the same pattern as the existing `is indexable by zip_code and distance` test
- All existing tests remain unchanged and should continue to pass

### How to Test Manually
1. Start the server with `bundle exec jets server`
2. Test with zip code (existing functionality):
   ```
   GET /api/agencies?zip_code=43219&distance=10
   ```
3. Test with lat/long (fixed functionality):
   ```
   GET /api/agencies?lat=40.0131&long=-82.9236&distance=10
   ```

Both requests should now correctly return only agencies within the specified distance.

### Impact
- **Backwards compatible**: No breaking changes
- **Bug fix only**: No new features or API changes
- **Performance**: No performance impact